### PR TITLE
Fixed Podfile and project configuration

### DIFF
--- a/Headlines.xcodeproj/project.pbxproj
+++ b/Headlines.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		133B125AD494C219DB3B0255 /* Pods_Canillitapp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1E364D941A8F5CACBFF8FD34 /* Pods_Canillitapp.framework */; };
 		597E81BAC05CC01C523956BE /* Pods_Watch_Extension.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E7CA813EE9F2943ACC02746E /* Pods_Watch_Extension.framework */; };
 		670D2C7C1DDC09D000237C39 /* NewsTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 670D2C7B1DDC09D000237C39 /* NewsTableViewCell.swift */; };
 		6719DA631D6D143E00D1E214 /* Interface.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 6719DA611D6D143E00D1E214 /* Interface.storyboard */; };
@@ -44,7 +45,6 @@
 		67E1A7A61DDD3744002AADEA /* Topic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67E1A7A51DDD3744002AADEA /* Topic.swift */; };
 		67E1A7A71DDD3881002AADEA /* Topic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67E1A7A51DDD3744002AADEA /* Topic.swift */; };
 		67FD84DE1D6BF85D00BACAFC /* TrendingCardsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67FD84DA1D6BF85D00BACAFC /* TrendingCardsViewController.swift */; };
-		CB5776E0C1E4A0AD0C481A5C /* Pods_Headlines.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 884A5BFA52E8811A2C5A6A7D /* Pods_Headlines.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -105,6 +105,7 @@
 
 /* Begin PBXFileReference section */
 		0DF05652C0E59CFCA3F26160 /* Pods-Watch Extension.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Watch Extension.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Watch Extension/Pods-Watch Extension.debug.xcconfig"; sourceTree = "<group>"; };
+		1E364D941A8F5CACBFF8FD34 /* Pods_Canillitapp.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Canillitapp.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		5EA3242399336F7A8DE27E42 /* Pods-Watch Extension.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Watch Extension.release.xcconfig"; path = "Pods/Target Support Files/Pods-Watch Extension/Pods-Watch Extension.release.xcconfig"; sourceTree = "<group>"; };
 		670D2C7B1DDC09D000237C39 /* NewsTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NewsTableViewCell.swift; sourceTree = "<group>"; };
 		6719DA5F1D6D143E00D1E214 /* Watch.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Watch.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -149,7 +150,9 @@
 		67FD84DA1D6BF85D00BACAFC /* TrendingCardsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrendingCardsViewController.swift; sourceTree = "<group>"; };
 		76124FBA967C0DCF6FC87B1F /* Pods-Headlines.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Headlines.release.xcconfig"; path = "Pods/Target Support Files/Pods-Headlines/Pods-Headlines.release.xcconfig"; sourceTree = "<group>"; };
 		884A5BFA52E8811A2C5A6A7D /* Pods_Headlines.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Headlines.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		BF6FCFB06FB814847D111266 /* Pods-Canillitapp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Canillitapp.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Canillitapp/Pods-Canillitapp.debug.xcconfig"; sourceTree = "<group>"; };
 		CBCA2736BC05D788D049F5CF /* Pods-Headlines.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Headlines.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Headlines/Pods-Headlines.debug.xcconfig"; sourceTree = "<group>"; };
+		D92054C908EB67709F7A5EC5 /* Pods-Canillitapp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Canillitapp.release.xcconfig"; path = "Pods/Target Support Files/Pods-Canillitapp/Pods-Canillitapp.release.xcconfig"; sourceTree = "<group>"; };
 		E7CA813EE9F2943ACC02746E /* Pods_Watch_Extension.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Watch_Extension.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -166,8 +169,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				CB5776E0C1E4A0AD0C481A5C /* Pods_Headlines.framework in Frameworks */,
 				67897EB21EA70B2B0084F598 /* CloudKit.framework in Frameworks */,
+				133B125AD494C219DB3B0255 /* Pods_Canillitapp.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -337,6 +340,7 @@
 				67897EB11EA70B2B0084F598 /* CloudKit.framework */,
 				884A5BFA52E8811A2C5A6A7D /* Pods_Headlines.framework */,
 				E7CA813EE9F2943ACC02746E /* Pods_Watch_Extension.framework */,
+				1E364D941A8F5CACBFF8FD34 /* Pods_Canillitapp.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -348,6 +352,8 @@
 				76124FBA967C0DCF6FC87B1F /* Pods-Headlines.release.xcconfig */,
 				0DF05652C0E59CFCA3F26160 /* Pods-Watch Extension.debug.xcconfig */,
 				5EA3242399336F7A8DE27E42 /* Pods-Watch Extension.release.xcconfig */,
+				BF6FCFB06FB814847D111266 /* Pods-Canillitapp.debug.xcconfig */,
+				D92054C908EB67709F7A5EC5 /* Pods-Canillitapp.release.xcconfig */,
 			);
 			name = Pods;
 			sourceTree = "<group>";
@@ -595,7 +601,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Headlines/Pods-Headlines-resources.sh\"\n";
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Canillitapp/Pods-Canillitapp-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		600A534BDF5ECF37B13E3932 /* [CP] Embed Pods Frameworks */ = {
@@ -639,7 +645,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Headlines/Pods-Headlines-frameworks.sh\"\n";
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Canillitapp/Pods-Canillitapp-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		ACDDC73AB3F5EA8DC32646D3 /* [CP] Check Pods Manifest.lock */ = {
@@ -955,7 +961,7 @@
 		};
 		675A82071D6BF6E8000DC680 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = CBCA2736BC05D788D049F5CF /* Pods-Headlines.debug.xcconfig */;
+			baseConfigurationReference = BF6FCFB06FB814847D111266 /* Pods-Canillitapp.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Headlines/Headlines.entitlements;
@@ -975,7 +981,7 @@
 		};
 		675A82081D6BF6E8000DC680 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 76124FBA967C0DCF6FC87B1F /* Pods-Headlines.release.xcconfig */;
+			baseConfigurationReference = D92054C908EB67709F7A5EC5 /* Pods-Canillitapp.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Headlines/Headlines.entitlements;

--- a/Podfile
+++ b/Podfile
@@ -3,13 +3,13 @@ source 'https://github.com/CocoaPods/Specs.git'
 inhibit_all_warnings!
 use_frameworks!
 
-target 'Headlines' do
+target 'Canillitapp' do
   platform :ios, '9.0'
-  pod 'SwiftyJSON', '3.1.1'
+  pod 'SwiftyJSON', '3.1.0'
   pod 'SDWebImage'
 end
 
 target 'Watch Extension' do
   platform :watchos, '2.0'
-  pod 'SwiftyJSON', '3.1.1'
+  pod 'SwiftyJSON', '3.1.0'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -2,16 +2,16 @@ PODS:
   - SDWebImage (3.8.2):
     - SDWebImage/Core (= 3.8.2)
   - SDWebImage/Core (3.8.2)
-  - SwiftyJSON (3.1.1)
+  - SwiftyJSON (3.1.0)
 
 DEPENDENCIES:
   - SDWebImage
-  - SwiftyJSON (= 3.1.1)
+  - SwiftyJSON (= 3.1.0)
 
 SPEC CHECKSUMS:
   SDWebImage: '098e97e6176540799c27e804c96653ee0833d13c'
-  SwiftyJSON: f0be2e604f83e8405a624e9f891898bf6ed4e019
+  SwiftyJSON: 29b9f2a64f118c07e691667c2ba1efe536acfe0b
 
-PODFILE CHECKSUM: b40cd3fadd6098f43425434bb5e7fe8ac9886815
+PODFILE CHECKSUM: ab60beee1a08b756c92aa974c8d4839020e5c0a2
 
 COCOAPODS: 1.2.0


### PR DESCRIPTION
It seems that after the target was renamed the Podfile got outdated and cocoapods wasn't working anymore so no "pod install" command could be executed on the project.

I updated the Podfile and the project configuration so it aligns with the new branding.

I also had to downgrade SwiftyJSON from 3.1.1 to 3.1.0 as 3.1.1 is not working anymore on Cocoapods:
https://github.com/SwiftyJSON/SwiftyJSON/issues/839
 