### PR TITLE
Handle push notification authorization status

### DIFF
--- a/Headlines/Base.lproj/Profile.storyboard
+++ b/Headlines/Base.lproj/Profile.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="A1F-p7-8G2">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="A1F-p7-8G2">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
         <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -156,6 +156,7 @@
                     </view>
                     <connections>
                         <outlet property="subscribeButton" destination="SP1-BB-aaE" id="LYf-Vm-xzf"/>
+                        <outlet property="subscribeLabel" destination="HhB-FB-VV3" id="loW-jr-jZs"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="eBV-bO-cwH" userLabel="First Responder" sceneMemberID="firstResponder"/>

--- a/Headlines/src/Controllers/SettingsViewController.swift
+++ b/Headlines/src/Controllers/SettingsViewController.swift
@@ -10,19 +10,102 @@ import UIKit
 import UserNotifications
 
 class SettingsViewController: UIViewController {
+
+    // MARK: - IBOutlets
     @IBOutlet weak var subscribeButton: UIButton!
+    @IBOutlet weak var subscribeLabel: UILabel!
+
+    // MARK: - Properties
+    var userNotificationCenter = UNUserNotificationCenter.current()
+    
+    // MARK: - Init & Deinit
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        registerApplicationWillEnterForeground()
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+    
+    // MARK: - View Lifecycle
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        layout()
+    }
+    
+    @objc func layout() {
+        userNotificationCenter.getNotificationSettings { settings in
+            switch settings.authorizationStatus {
+            case .notDetermined, .denied:
+                self.layoutAskForNotifications()
+            case .authorized:
+                self.layoutNotificationsAuthorized()
+            }
+        }
+    }
+    
+    private func layoutAskForNotifications() {
+        DispatchQueue.main.async {
+            self.subscribeButton.isEnabled = true
+            self.subscribeButton.setTitle("Suscribirse a notificaciones",
+                                          for: .normal)
+            self.subscribeLabel.text =
+            "Al suscribirte, recibirás una notificación sobre una noticia importante una vez al día"
+        }
+    }
+    
+    private func layoutNotificationsAuthorized() {
+        DispatchQueue.main.async {
+            self.subscribeButton.isEnabled = false
+            self.subscribeButton.setTitle("✅",
+                                          for: .normal)
+            self.subscribeLabel.text =
+            "Ya estas suscripto! Estarás recibiendo una notificación sobre una noticia importa una vez al dia."
+        }
+    }
+    
+    private func checkRemoteNotificationsStatus() {
+        userNotificationCenter.getNotificationSettings { settings in
+            switch settings.authorizationStatus {
+            case .notDetermined:
+                // Push notifications permissions haven't been asked yet.
+                self.registerForRemoteNotifications()
+            case .denied:
+                // Push notifications where denied so we open the app page
+                // on Settings.
+                DispatchQueue.main.async {
+                    let url = URL(string: UIApplicationOpenSettingsURLString)!
+                    UIApplication.shared.open(url)
+                }
+            case .authorized:
+                assertionFailure("Suscribe button was enabled while the notifications where already authorized.")
+                self.layoutNotificationsAuthorized()
+            }
+        }
+    }
 
     private func registerForRemoteNotifications() {
-        UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound]) { (granted, error) in
+        userNotificationCenter.requestAuthorization(options: [.alert, .sound]) { granted, _ in
             DispatchQueue.main.async {
                 if granted {
                     UIApplication.shared.registerForRemoteNotifications()
+                    self.layoutNotificationsAuthorized()
                 }
             }
         }
     }
     
     @IBAction func subscribeButtonPressed(_ sender: Any) {
-        registerForRemoteNotifications()
+        checkRemoteNotificationsStatus()
+    }
+    
+    private func registerApplicationWillEnterForeground() {
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(self.layout),
+            name: Notification.Name.UIApplicationWillEnterForeground,
+            object: nil
+        )
     }
 }


### PR DESCRIPTION
This PR adds support for handling the different `UNNotificationSettings` status. It will prompt the push notification permission alert on `.notDetermined` and take you to the app page on iOS Settings for `.denied`. The UI updates depending on your current status as well (examples attached).

### Images
`.denied` | `.notDetermined`

<img src="https://user-images.githubusercontent.com/14804033/42331404-b65b5a92-804b-11e8-9805-c3f37e64a761.png" width="300">

`.authorized`

<img src="https://user-images.githubusercontent.com/14804033/42331403-b635bd96-804b-11e8-823a-020009bf2b72.png" width="300">