### PR TITLE
Remove SwiftyJSON dependency by using the Decodable protocol

### DIFF
--- a/Common/models/News.swift
+++ b/Common/models/News.swift
@@ -7,10 +7,9 @@
 //
 
 import Foundation
-import SwiftyJSON
 
-class News: NSObject {
-    var identifier: String?
+class News: NSObject, Decodable {
+    var newsId: Int?
     var title: String?
     var url: URL?
     var date: Date?
@@ -19,6 +18,13 @@ class News: NSObject {
     var imageUrl: URL?
     var reactions: [Reaction]?
     
+    var identifier: String? {
+        guard let newsId = newsId else {
+            return nil
+        }
+        return "\(newsId)"
+    }
+
     var representativeReaction: Reaction? {
         guard let r = reactions?.sorted(by: { (reactionA, reactionB) -> Bool in
             return reactionA.amount > reactionB.amount
@@ -32,34 +38,29 @@ class News: NSObject {
     override init() {
         super.init()
     }
+
+    // MARK: - Decodable
+    enum CodingKeys: String, CodingKey {
+        case newsId = "news_id"
+        case title
+        case url
+        case date
+        case source = "source_name"
+        case category
+        case imageUrl = "img_url"
+        case reactions
+    }
     
-    init(json: JSON) {
-        
-        if let newsId = json["news_id"].int {
-            identifier = "\(newsId)"
-        }
-        
-        title = json["title"].string
-        url = json["url"].url
-        
-        let timestamp = json["date"].doubleValue
-        date = Date(timeIntervalSince1970: timestamp)
-        
-        source = json["source_name"].string
-        
-        category = json["category"].string
-        
-        imageUrl = json["img_url"].url
-        
-        var tmp: [Reaction] = []
-        
-        json["reactions"].forEach ({ (_, j) in
-            let r = Reaction(json: j)
-            tmp.append(r)
-        })
-        
-        reactions = tmp
-        
-        super.init()
+    required init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        newsId = try container.decode(Int.self, forKey: .newsId)
+        title = try container.decode(String.self, forKey: .title)
+        url = try container.decode(URL.self, forKey: .url)
+        let decodedDate = try container.decode(Int.self, forKey: .date)
+        date = Date(timeIntervalSince1970: TimeInterval(decodedDate))
+        source = try container.decodeIfPresent(String.self, forKey: .source)
+        category = try container.decodeIfPresent(String.self, forKey: .category)
+        imageUrl = try container.decodeIfPresent(URL.self, forKey: .imageUrl)
+        reactions = try container.decodeIfPresent([Reaction].self, forKey: .reactions)
     }
 }

--- a/Common/models/Reaction.swift
+++ b/Common/models/Reaction.swift
@@ -7,9 +7,8 @@
 //
 
 import UIKit
-import SwiftyJSON
 
-class Reaction: NSObject {
+class Reaction: NSObject, Decodable {
     var reaction: String
     var amount: Int
     var news: News?
@@ -19,28 +18,21 @@ class Reaction: NSObject {
         return "\(self.reaction) \(self.amount)"
     }
     
-    init(json: JSON) {
-        
-        if let r = json["reaction"].string {
-            reaction = r
-        } else {
-            reaction = "🤦🏿‍♂️"
-        }
-        
-        if let i = json["amount"].int {
-            amount = i
-        } else {
-            amount = 0
-        }
-        
-        let timestamp = json["date"].doubleValue
-        date = Date(timeIntervalSince1970: timestamp)
-        
-        if json["news"].exists() {
-            news = News(json: json["news"])
-        }
-
-        super.init()
+    // MARK: - Decodable
+    enum CodingKeys: String, CodingKey {
+        case reaction
+        case amount
+        case news
+        case date
+    }
+    
+    required init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        reaction = try container.decode(String.self, forKey: .reaction)
+        amount = (try? container.decode(Int.self, forKey: .amount)) ?? 0
+        news = try container.decodeIfPresent(News.self, forKey: .news)
+        let decodedDate = try container.decode(Int.self, forKey: .date)
+        date = Date(timeIntervalSince1970: TimeInterval(decodedDate))
     }
     
     init(reaction: String, amount: Int) {

--- a/Common/models/Safe.swift
+++ b/Common/models/Safe.swift
@@ -1,0 +1,24 @@
+//
+//  Safe.swift
+//  Headlines
+//
+//  Created by Marcos Griselli on 25/07/2018.
+//  Copyright © 2018 Ezequiel Becerra. All rights reserved.
+//
+
+import Foundation
+
+public struct Safe<Base: Decodable>: Decodable {
+    public let value: Base?
+    
+    public init(from decoder: Decoder) throws {
+        do {
+            let container = try decoder.singleValueContainer()
+            value = try container.decode(Base.self)
+        } catch {
+            assertionFailure("ERROR: \(error)")
+//            Crashlytics.sharedInstance().recordError(error)
+            value = nil
+        }
+    }
+}

--- a/Common/models/Topic.swift
+++ b/Common/models/Topic.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-class Topic: NSObject {
+class Topic: NSObject, Decodable {
     var name: String?
     var date: Date?
     var news: [News]?

--- a/Common/models/TopicResponse.swift
+++ b/Common/models/TopicResponse.swift
@@ -1,0 +1,24 @@
+//
+//  TopicResponse.swift
+//  Canillitapp
+//
+//  Created by Marcos Griselli on 21/07/2018.
+//  Copyright © 2018 Ezequiel Becerra. All rights reserved.
+//
+
+import Foundation
+
+struct TopicResponse: Decodable {
+    let keywords: [String]
+    let news: [String: [News]]
+    
+    func topics(date: Date) -> [Topic] {
+        return news.map { news -> Topic in
+            let topic = Topic()
+            topic.name = news.key
+            topic.date = date
+            topic.news = news.value
+            return topic
+        }
+    }
+}

--- a/Common/models/TrendingTerm.swift
+++ b/Common/models/TrendingTerm.swift
@@ -7,18 +7,8 @@
 //
 
 import Foundation
-import SwiftyJSON
 
-struct TrendingTerm {
+struct TrendingTerm: Decodable {
     let criteria: String
     let quantity: Int
-    
-    init?(json: JSON) {
-        guard let criteria = json["criteria"].string,
-            let quantity = json["quantity"].int else {
-                return nil
-        }
-        self.criteria = criteria
-        self.quantity = quantity
-    }
 }

--- a/Common/services/mocks/GET-trending.json
+++ b/Common/services/mocks/GET-trending.json
@@ -222,7 +222,7 @@
       {
         "news_id": 167578,
         "url": "http://www.minutouno.com/notas/1555488-aflojame-un-poquito-la-respuesta-macri-una-chica-que-queria-una-selfie",
-        "title": "\"Aflojame un poquito\":  la respuesta de Macri con una chica que quería una selfie",
+        "title": "\\\"Aflojame un poquito\\\":  la respuesta de Macri con una chica que quería una selfie",
         "date": 1496838180,
         "source_id": 11,
         "img_url": "http://static.minutouno.com/adjuntos/150/imagenes/011/471/0011471246.jpg",

--- a/Headlines.xcodeproj/project.pbxproj
+++ b/Headlines.xcodeproj/project.pbxproj
@@ -7,13 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		05859035133DF872C4F9775C /* Pods_HeadlinesTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EBA7D61C153D8B95DB9A361C /* Pods_HeadlinesTests.framework */; };
-		08997FABEA8931BE95F4D46A /* Pods_Canillitapp_Widget.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E3844BADA0445D4FFEA53F73 /* Pods_Canillitapp_Widget.framework */; };
 		133B125AD494C219DB3B0255 /* Pods_Canillitapp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1E364D941A8F5CACBFF8FD34 /* Pods_Canillitapp.framework */; };
 		43CC643D1EBBE7E90066D49E /* OrientationAwareControllers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43CC643C1EBBE7E90066D49E /* OrientationAwareControllers.swift */; };
 		43CC643E1EBBE7E90066D49E /* OrientationAwareControllers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43CC643C1EBBE7E90066D49E /* OrientationAwareControllers.swift */; };
 		43CC643F1EBBE7E90066D49E /* OrientationAwareControllers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43CC643C1EBBE7E90066D49E /* OrientationAwareControllers.swift */; };
-		597E81BAC05CC01C523956BE /* Pods_Watch_Extension.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E7CA813EE9F2943ACC02746E /* Pods_Watch_Extension.framework */; };
 		67026FFE20FEE55300F67B90 /* GET-search-trending.json in Resources */ = {isa = PBXBuildFile; fileRef = 67026FFD20FEE55300F67B90 /* GET-search-trending.json */; };
 		6702700020FEE6C300F67B90 /* GET-search-term.json in Resources */ = {isa = PBXBuildFile; fileRef = 67026FFF20FEE6C300F67B90 /* GET-search-term.json */; };
 		6704850620F952E300360701 /* ReviewView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 6704850520F952E300360701 /* ReviewView.xib */; };
@@ -152,9 +149,15 @@
 		FB9F586B20FA34730028C1DF /* Tag.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB9F586A20FA34730028C1DF /* Tag.swift */; };
 		FB9F586C20FA34970028C1DF /* Tag.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB9F586A20FA34730028C1DF /* Tag.swift */; };
 		FB9F586D20FA34970028C1DF /* Tag.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB9F586A20FA34730028C1DF /* Tag.swift */; };
+		FBA2DD022109430400BDC058 /* Safe.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBA2DD012109430400BDC058 /* Safe.swift */; };
+		FBA2DD032109430400BDC058 /* Safe.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBA2DD012109430400BDC058 /* Safe.swift */; };
+		FBA2DD042109430400BDC058 /* Safe.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBA2DD012109430400BDC058 /* Safe.swift */; };
 		FBBDCC6E20F2C3B200757861 /* TrendingTerm.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBBDCC6D20F2C3B200757861 /* TrendingTerm.swift */; };
 		FBBDCC6F20F2C59E00757861 /* TrendingTerm.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBBDCC6D20F2C3B200757861 /* TrendingTerm.swift */; };
 		FBBDCC7020F2C59E00757861 /* TrendingTerm.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBBDCC6D20F2C3B200757861 /* TrendingTerm.swift */; };
+		FBF21AE32103F30100C0FA76 /* TopicResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBF21AE22103F30100C0FA76 /* TopicResponse.swift */; };
+		FBF21AE42103F3A700C0FA76 /* TopicResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBF21AE22103F30100C0FA76 /* TopicResponse.swift */; };
+		FBF21AE52103F3A800C0FA76 /* TopicResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBF21AE22103F30100C0FA76 /* TopicResponse.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -254,11 +257,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		0DF05652C0E59CFCA3F26160 /* Pods-Watch Extension.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Watch Extension.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Watch Extension/Pods-Watch Extension.debug.xcconfig"; sourceTree = "<group>"; };
-		1B88713190516178E6891750 /* Pods-HeadlinesTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HeadlinesTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-HeadlinesTests/Pods-HeadlinesTests.debug.xcconfig"; sourceTree = "<group>"; };
 		1E364D941A8F5CACBFF8FD34 /* Pods_Canillitapp.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Canillitapp.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		43CC643C1EBBE7E90066D49E /* OrientationAwareControllers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OrientationAwareControllers.swift; sourceTree = "<group>"; };
-		5EA3242399336F7A8DE27E42 /* Pods-Watch Extension.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Watch Extension.release.xcconfig"; path = "Pods/Target Support Files/Pods-Watch Extension/Pods-Watch Extension.release.xcconfig"; sourceTree = "<group>"; };
 		67026FFD20FEE55300F67B90 /* GET-search-trending.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "GET-search-trending.json"; sourceTree = "<group>"; };
 		67026FFF20FEE6C300F67B90 /* GET-search-term.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "GET-search-term.json"; sourceTree = "<group>"; };
 		6704850520F952E300360701 /* ReviewView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ReviewView.xib; sourceTree = "<group>"; };
@@ -384,9 +384,7 @@
 		67F39C191EB2DEE600CF99F2 /* SearchViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchViewController.swift; sourceTree = "<group>"; };
 		67FD84DA1D6BF85D00BACAFC /* TrendingCardsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrendingCardsViewController.swift; sourceTree = "<group>"; };
 		76124FBA967C0DCF6FC87B1F /* Pods-Headlines.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Headlines.release.xcconfig"; path = "Pods/Target Support Files/Pods-Headlines/Pods-Headlines.release.xcconfig"; sourceTree = "<group>"; };
-		7FF29453467C8A7C0AD8C91C /* Pods-Canillitapp Widget.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Canillitapp Widget.release.xcconfig"; path = "Pods/Target Support Files/Pods-Canillitapp Widget/Pods-Canillitapp Widget.release.xcconfig"; sourceTree = "<group>"; };
 		884A5BFA52E8811A2C5A6A7D /* Pods_Headlines.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Headlines.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		BD02F270E52E39395541E474 /* Pods-Canillitapp Widget.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Canillitapp Widget.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Canillitapp Widget/Pods-Canillitapp Widget.debug.xcconfig"; sourceTree = "<group>"; };
 		BF6FCFB06FB814847D111266 /* Pods-Canillitapp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Canillitapp.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Canillitapp/Pods-Canillitapp.debug.xcconfig"; sourceTree = "<group>"; };
 		CBCA2736BC05D788D049F5CF /* Pods-Headlines.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Headlines.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Headlines/Pods-Headlines.debug.xcconfig"; sourceTree = "<group>"; };
 		D92054C908EB67709F7A5EC5 /* Pods-Canillitapp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Canillitapp.release.xcconfig"; path = "Pods/Target Support Files/Pods-Canillitapp/Pods-Canillitapp.release.xcconfig"; sourceTree = "<group>"; };
@@ -406,8 +404,9 @@
 		FB9F586420FA2B4F0028C1DF /* SuggestedTermsTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestedTermsTableViewController.swift; sourceTree = "<group>"; };
 		FB9F586820FA2BB30028C1DF /* SuggestedTermTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestedTermTableViewCell.swift; sourceTree = "<group>"; };
 		FB9F586A20FA34730028C1DF /* Tag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tag.swift; sourceTree = "<group>"; };
+		FBA2DD012109430400BDC058 /* Safe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Safe.swift; sourceTree = "<group>"; };
 		FBBDCC6D20F2C3B200757861 /* TrendingTerm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrendingTerm.swift; sourceTree = "<group>"; };
-		FD39590F765C68237C475997 /* Pods-HeadlinesTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HeadlinesTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-HeadlinesTests/Pods-HeadlinesTests.release.xcconfig"; sourceTree = "<group>"; };
+		FBF21AE22103F30100C0FA76 /* TopicResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopicResponse.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -422,7 +421,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				597E81BAC05CC01C523956BE /* Pods_Watch_Extension.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -446,7 +444,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				05859035133DF872C4F9775C /* Pods_HeadlinesTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -469,7 +466,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				67BA65C41FCB65B400411A06 /* NotificationCenter.framework in Frameworks */,
-				08997FABEA8931BE95F4D46A /* Pods_Canillitapp_Widget.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -743,8 +739,10 @@
 				6797F8A61EE4B38E00B8EAA5 /* News.swift */,
 				6797F8A71EE4B38E00B8EAA5 /* Reaction.swift */,
 				6797F8A81EE4B38E00B8EAA5 /* Topic.swift */,
+				FBF21AE22103F30100C0FA76 /* TopicResponse.swift */,
 				FBBDCC6D20F2C3B200757861 /* TrendingTerm.swift */,
 				FB9F586A20FA34730028C1DF /* Tag.swift */,
+				FBA2DD012109430400BDC058 /* Safe.swift */,
 			);
 			path = models;
 			sourceTree = "<group>";
@@ -882,14 +880,8 @@
 			children = (
 				CBCA2736BC05D788D049F5CF /* Pods-Headlines.debug.xcconfig */,
 				76124FBA967C0DCF6FC87B1F /* Pods-Headlines.release.xcconfig */,
-				0DF05652C0E59CFCA3F26160 /* Pods-Watch Extension.debug.xcconfig */,
-				5EA3242399336F7A8DE27E42 /* Pods-Watch Extension.release.xcconfig */,
 				BF6FCFB06FB814847D111266 /* Pods-Canillitapp.debug.xcconfig */,
 				D92054C908EB67709F7A5EC5 /* Pods-Canillitapp.release.xcconfig */,
-				BD02F270E52E39395541E474 /* Pods-Canillitapp Widget.debug.xcconfig */,
-				7FF29453467C8A7C0AD8C91C /* Pods-Canillitapp Widget.release.xcconfig */,
-				1B88713190516178E6891750 /* Pods-HeadlinesTests.debug.xcconfig */,
-				FD39590F765C68237C475997 /* Pods-HeadlinesTests.release.xcconfig */,
 			);
 			name = Pods;
 			sourceTree = "<group>";
@@ -983,11 +975,9 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 6719DA7E1D6D143E00D1E214 /* Build configuration list for PBXNativeTarget "Watch Extension" */;
 			buildPhases = (
-				111875771CA35CA2D69BBEA3 /* [CP] Check Pods Manifest.lock */,
 				6719DA671D6D143E00D1E214 /* Sources */,
 				6719DA681D6D143E00D1E214 /* Frameworks */,
 				6719DA691D6D143E00D1E214 /* Resources */,
-				600A534BDF5ECF37B13E3932 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -1046,11 +1036,9 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 675A82091D6BF6E8000DC680 /* Build configuration list for PBXNativeTarget "HeadlinesTests" */;
 			buildPhases = (
-				5604A0896EEE31CC31C651B9 /* [CP] Check Pods Manifest.lock */,
 				675A81EE1D6BF6E8000DC680 /* Sources */,
 				675A81EF1D6BF6E8000DC680 /* Frameworks */,
 				675A81F01D6BF6E8000DC680 /* Resources */,
-				F50E08302FC8D3BE7C7E301B /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -1101,7 +1089,6 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 67BA65D11FCB65B400411A06 /* Build configuration list for PBXNativeTarget "Canillitapp Widget" */;
 			buildPhases = (
-				BF46BDF242B4FBEE1F5C8EF7 /* [CP] Check Pods Manifest.lock */,
 				67BA65BE1FCB65B400411A06 /* Sources */,
 				67BA65BF1FCB65B400411A06 /* Frameworks */,
 				67BA65C01FCB65B400411A06 /* Resources */,
@@ -1317,60 +1304,6 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		111875771CA35CA2D69BBEA3 /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-Watch Extension-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		5604A0896EEE31CC31C651B9 /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-HeadlinesTests-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		600A534BDF5ECF37B13E3932 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-Watch Extension/Pods-Watch Extension-frameworks.sh",
-				"${BUILT_PRODUCTS_DIR}/SwiftyJSON-watchOS/SwiftyJSON.framework",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SwiftyJSON.framework",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Watch Extension/Pods-Watch Extension-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 		6798B6841EBABFB50079B8E1 /* Crashlytics */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -1407,13 +1340,11 @@
 			inputPaths = (
 				"${SRCROOT}/Pods/Target Support Files/Pods-Canillitapp/Pods-Canillitapp-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/SDWebImage/SDWebImage.framework",
-				"${BUILT_PRODUCTS_DIR}/SwiftyJSON-iOS/SwiftyJSON.framework",
 				"${BUILT_PRODUCTS_DIR}/ViewAnimator/ViewAnimator.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SDWebImage.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SwiftyJSON.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ViewAnimator.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1439,42 +1370,6 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		BF46BDF242B4FBEE1F5C8EF7 /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-Canillitapp Widget-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		F50E08302FC8D3BE7C7E301B /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-HeadlinesTests/Pods-HeadlinesTests-frameworks.sh",
-				"${BUILT_PRODUCTS_DIR}/SwiftyJSON-iOS/SwiftyJSON.framework",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SwiftyJSON.framework",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-HeadlinesTests/Pods-HeadlinesTests-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -1494,11 +1389,13 @@
 				6797F8B31EE4B38E00B8EAA5 /* Topic.swift in Sources */,
 				FBBDCC6F20F2C59E00757861 /* TrendingTerm.swift in Sources */,
 				67C3CD3D1D6D1876003CC04E /* TrendingInterfaceController.swift in Sources */,
+				FBA2DD032109430400BDC058 /* Safe.swift in Sources */,
 				6719DA731D6D143E00D1E214 /* ExtensionDelegate.swift in Sources */,
 				67C3CD3F1D6D1A68003CC04E /* TrendingRowController.swift in Sources */,
 				6797F8AF1EE4B38E00B8EAA5 /* News.swift in Sources */,
 				6797F8BD1EE4D17E00B8EAA5 /* MockService.swift in Sources */,
 				677AE3481D6E7FE900CD710D /* NewsRowController.swift in Sources */,
+				FBF21AE42103F3A700C0FA76 /* TopicResponse.swift in Sources */,
 				6797F8B11EE4B38E00B8EAA5 /* Reaction.swift in Sources */,
 				FB9F586C20FA34970028C1DF /* Tag.swift in Sources */,
 				6797F8B51EE4B38E00B8EAA5 /* HTTPService.swift in Sources */,
@@ -1545,6 +1442,7 @@
 				67CE08B11E9012F700D5911E /* NewsCellViewModel.swift in Sources */,
 				FB0F97F720F8D51A00555A7A /* Array+Util.swift in Sources */,
 				675A81E01D6BF6E8000DC680 /* AppDelegate.swift in Sources */,
+				FBA2DD022109430400BDC058 /* Safe.swift in Sources */,
 				FB450E1620F2AF9A00084445 /* ContentStateViewController.swift in Sources */,
 				FB9F586920FA2BB30028C1DF /* SuggestedTermTableViewCell.swift in Sources */,
 				FB450E1320F2AF2500084445 /* UIViewController+Child.swift in Sources */,
@@ -1564,6 +1462,7 @@
 				670D6D0D1FB3F2DD003B5B33 /* UIViewController+Switcher.swift in Sources */,
 				670D6D081FB3E098003B5B33 /* ScreenSwitcherViewController.swift in Sources */,
 				674E7D0320E1CF9C007A8337 /* CategoryNewsDataSource.swift in Sources */,
+				FBF21AE32103F30100C0FA76 /* TopicResponse.swift in Sources */,
 				67BC0913204B35D400796B8B /* NewsPreviewViewController.swift in Sources */,
 				6767C59D204A4F6F00D909E1 /* FilterSourcesDataSource.swift in Sources */,
 				6757E984201ACCF2002AC331 /* UsersService.swift in Sources */,
@@ -1623,6 +1522,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				FBF21AE52103F3A800C0FA76 /* TopicResponse.swift in Sources */,
 				FBBDCC7020F2C59E00757861 /* TrendingTerm.swift in Sources */,
 				67BA65C71FCB65B400411A06 /* TodayViewController.swift in Sources */,
 				671513161FCB6C1500D4638F /* Reaction.swift in Sources */,
@@ -1631,6 +1531,7 @@
 				671513171FCB6C1800D4638F /* News.swift in Sources */,
 				FB9F586D20FA34970028C1DF /* Tag.swift in Sources */,
 				671513191FCB6C2800D4638F /* HTTPService.swift in Sources */,
+				FBA2DD042109430400BDC058 /* Safe.swift in Sources */,
 				671513181FCB6C1C00D4638F /* ConfigHelper.swift in Sources */,
 				671513151FCB6C1200D4638F /* Topic.swift in Sources */,
 				673880B21FD21896001005FF /* TodayViewModel.swift in Sources */,
@@ -1863,7 +1764,6 @@
 		};
 		6719DA7C1D6D143E00D1E214 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 0DF05652C0E59CFCA3F26160 /* Pods-Watch Extension.debug.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "iPhone Developer";
@@ -1887,7 +1787,6 @@
 		};
 		6719DA7D1D6D143E00D1E214 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 5EA3242399336F7A8DE27E42 /* Pods-Watch Extension.release.xcconfig */;
 			buildSettings = {
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "iPhone Developer";
 				CURRENT_PROJECT_VERSION = 527;
@@ -2083,7 +1982,6 @@
 		};
 		675A820A1D6BF6E8000DC680 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 1B88713190516178E6891750 /* Pods-HeadlinesTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				DEVELOPMENT_TEAM = 2334RGUT2P;
@@ -2099,7 +1997,6 @@
 		};
 		675A820B1D6BF6E8000DC680 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = FD39590F765C68237C475997 /* Pods-HeadlinesTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				DEVELOPMENT_TEAM = 2334RGUT2P;
@@ -2210,7 +2107,6 @@
 		};
 		67BA65CF1FCB65B400411A06 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = BD02F270E52E39395541E474 /* Pods-Canillitapp Widget.debug.xcconfig */;
 			buildSettings = {
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
@@ -2242,7 +2138,6 @@
 		};
 		67BA65D01FCB65B400411A06 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 7FF29453467C8A7C0AD8C91C /* Pods-Canillitapp Widget.release.xcconfig */;
 			buildSettings = {
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";

--- a/Headlines/AppDelegate.swift
+++ b/Headlines/AppDelegate.swift
@@ -197,7 +197,7 @@ class AppDelegate: UIResponder,
             if let postURL = response.notification.request.content.userInfo["post-url"] as? String {
                 newsToOpen = News()
                 newsToOpen?.url = URL(string: postURL)
-                newsToOpen?.identifier = "\(postId)"
+                newsToOpen?.newsId = postId
                 
                 NotificationCenter.default.post(name: .notificationNewsTapped, object: newsToOpen)
             }

--- a/Headlines/src/Controllers/ProfileViewController.swift
+++ b/Headlines/src/Controllers/ProfileViewController.swift
@@ -66,11 +66,9 @@ class ProfileViewController: UITableViewController, TabbedViewController {
     @objc func fetchMyReactions() {
         self.startRefreshing()
         
-        let success: (URLResponse?, [Reaction]) -> Void = { [unowned self] response, reactions in
+        let success: (URLResponse?, [Reaction]?) -> Void = { [unowned self] response, reactions in
             self.endRefreshing()
-            
-            self.reactions.removeAll()
-            self.reactions.append(contentsOf: reactions)
+            self.reactions = reactions ?? [Reaction]()
             self.tableView.reloadData()
             
             if !ProcessInfo.processInfo.arguments.contains("mockRequests") {

--- a/Headlines/src/Controllers/Search/NewsSearchStateController.swift
+++ b/Headlines/src/Controllers/Search/NewsSearchStateController.swift
@@ -52,12 +52,14 @@ class NewsSearchStateController: UIViewController, UISearchResultsUpdating {
         stateViewController.transition(to: .render(newsController))
     }
     
-    private func render(tags: [Tag], searchedTerm: String) {
+    private func render(tags: [Tag]?, searchedTerm: String) {
         let storyboard = UIStoryboard(name: "Search", bundle: Bundle.main)
         let termsTableController = storyboard.instantiateViewController(
             withIdentifier: "SuggestedTermsTableViewController"
             ) as! SuggestedTermsTableViewController
-        termsTableController.tags = tags
+        if let tags = tags {
+            termsTableController.tags = tags
+        }
         termsTableController.searchedTerm = searchedTerm
         termsTableController.didSelect = didSelectSuggestion
         stateViewController.transition(to: .render(termsTableController))

--- a/Headlines/src/Controllers/Search/TrendingSearchViewController.swift
+++ b/Headlines/src/Controllers/Search/TrendingSearchViewController.swift
@@ -33,8 +33,8 @@ class TrendingSearchViewController: UITableViewController {
     }
     
     private func fetchTrending() {
-        service.fetchTrendingTerms(success: { [unowned self] in
-            self.terms = $0
+        service.fetchTrendingTerms(success: { [unowned self] terms in
+            self.terms = terms ?? [TrendingTerm]()
             if !ProcessInfo.processInfo.arguments.contains("mockRequests") {
                 self.refreshControl?.endRefreshing()
             }

--- a/Headlines/src/Models/Category.swift
+++ b/Headlines/src/Models/Category.swift
@@ -7,33 +7,30 @@
 //
 
 import Foundation
-import SwiftyJSON
 
-class Category {
-    let identifier: String
+class Category: Decodable {
+    
+    let identifier: Int
     let name: String
     var imageURL: URL?
     
-    init(identifier: String, name: String, imageURL: URL?) {
+    init(identifier: Int, name: String, imageURL: URL?) {
         self.identifier = identifier
         self.name = name
         self.imageURL = imageURL
     }
     
-    init(json: JSON) {
-        
-        if let categoryId = json["id"].int {
-            identifier = "\(categoryId)"
-        } else {
-            identifier = ""
-        }
-        
-        if let categoryName = json["name"].string {
-            name = categoryName
-        } else {
-            name = ""
-        }
-        
-        imageURL = json["img_url"].url
+    // MARK: - Decodable
+    enum CodingKeys: String, CodingKey {
+        case identifier = "id"
+        case name
+        case imageURL = "img_url"
+    }
+    
+    required init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        identifier = try container.decode(Int.self, forKey: .identifier)
+        name = try container.decode(String.self, forKey: .name)
+        imageURL = try container.decodeIfPresent(URL.self, forKey: .imageURL)
     }
 }

--- a/Headlines/src/Services/CategoriesService.swift
+++ b/Headlines/src/Services/CategoriesService.swift
@@ -7,27 +7,21 @@
 //
 
 import Foundation
-import SwiftyJSON
 
 class CategoriesService: HTTPService {
+    
+    private let decoder = JSONDecoder()
     
     func categoriesList (success: ((_ result: [Category]?) -> Void)?,
                          fail: ((_ error: NSError) -> Void)?) {
         
         let successBlock: (_ result: Data?, _ response: URLResponse?) -> Void = {(data, response) in
-            guard let d = data, let json = try? JSON(data: d) else {
+            guard let data = data else {
                 return
             }
-                    
-            var res = [Category]()
-            
-            for (_, v) in json {
-                let c = Category(json: v)
-                res.append(c)
-            }
-            
+            let categories = try? self.self.decoder.decode([Category].self, from: data)
             DispatchQueue.main.async(execute: {
-                success?(res)
+                success?(categories)
             })
         }
         

--- a/Headlines/src/Services/ReactionsService.swift
+++ b/Headlines/src/Services/ReactionsService.swift
@@ -8,7 +8,6 @@
 
 import UIKit
 import CloudKit
-import SwiftyJSON
 
 class ReactionsService: HTTPService {
 
@@ -34,14 +33,12 @@ class ReactionsService: HTTPService {
             }
             
             let successBlock: (_ result: Data?, _ response: URLResponse?) -> Void = {(data, response) in
-                guard let d = data, let json = try? JSON(data: d)  else {
+                guard let data = data else {
                     return
                 }
-                
-                let n = News(json: json)
-                
+                let news = try? JSONDecoder().decode(News.self, from: data)
                 DispatchQueue.main.async(execute: {
-                    success?(response, n)
+                    success?(response, news)
                 })
             }
             
@@ -65,20 +62,14 @@ class ReactionsService: HTTPService {
         }
     }
     
-    func getReactions(success: ((_ response: URLResponse?, [Reaction]) -> Void)?,
+    func getReactions(success: ((_ response: URLResponse?, [Reaction]?) -> Void)?,
                       fail: ((_ error: Error) -> Void)?) {
         
         let successBlock: (_ result: Data?, _ response: URLResponse?) -> Void = {(data, response) in
-            guard let d = data, let json = try? JSON(data: d) else {
+            guard let data = data else {
                 return
             }
-                        
-            var reactions = [Reaction]()
-            json.forEach ({ (_, j) in
-                let r = Reaction(json: j)
-                reactions.append(r)
-            })
-            
+            let reactions = try? JSONDecoder().decode([Reaction].self, from: data)
             DispatchQueue.main.async(execute: {
                 success?(response, reactions)
             })

--- a/HeadlinesTests/TopicTests.swift
+++ b/HeadlinesTests/TopicTests.swift
@@ -7,50 +7,23 @@
 //
 
 import XCTest
-import SwiftyJSON
 @testable import Canillitapp
 
 class TopicTests: XCTestCase {
     
-    var topics: [Topic]?
-    
-    override func setUp() {
-        super.setUp()
-        
+    func testRepresentativeReaction() throws {
         let path = Bundle.main.path(forResource: "topic_mock", ofType: "json")
         let url = URL(fileURLWithPath: path!)
-        do {
-            let data = try Data(contentsOf: url)
-            let json = try JSON(data: data)
-            topics = [Topic]()
-            
-            for (k, t) in json["news"] {
-                let a = Topic()
-                a.name = k
-                a.date = Date()
-                a.news = [News]()
-                
-                for (_, n) in t {
-                    let news = News(json: n)
-                    a.news!.append(news)
-                }
-                
-                topics?.append(a)
-            }
-        } catch {}
-    }
-    
-    override func tearDown() {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-        super.tearDown()
-    }
-    
-    func testRepresentativeReaction() {
-        guard let t = topics?.first else {
+        let decoder = JSONDecoder()
+        let data = try Data(contentsOf: url)
+        let topicResponse = try decoder.decode(TopicResponse.self, from: data)
+        let topics = topicResponse.topics(date: Date())
+        
+        guard let t = topics.first else {
             XCTAssert(false)
             return
         }
-        
+
         XCTAssertNotNil(t.representativeReaction)
         
         let topicRepresentativeReaction = t.representativeReaction?.reaction

--- a/Podfile
+++ b/Podfile
@@ -5,25 +5,9 @@ use_frameworks!
 
 target 'Canillitapp' do
   platform :ios, '10.0'
-  pod 'SwiftyJSON'
   pod 'SDWebImage'
   pod 'Fabric'
   pod 'Crashlytics'
   pod 'ViewAnimator'
-end
-
-target 'Watch Extension' do
-  platform :watchos, '3.0'
-  pod 'SwiftyJSON'
-end
-
-target 'Canillitapp Widget' do
-  platform :ios, '10.0'
-  pod 'SwiftyJSON'
-end
-
-target 'HeadlinesTests' do
-  platform :ios, '10.0'
-  pod 'SwiftyJSON'
 end
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -5,14 +5,12 @@ PODS:
   - SDWebImage (4.4.1):
     - SDWebImage/Core (= 4.4.1)
   - SDWebImage/Core (4.4.1)
-  - SwiftyJSON (4.1.0)
   - ViewAnimator (2.1.1)
 
 DEPENDENCIES:
   - Crashlytics
   - Fabric
   - SDWebImage
-  - SwiftyJSON
   - ViewAnimator
 
 SPEC REPOS:
@@ -20,16 +18,14 @@ SPEC REPOS:
     - Crashlytics
     - Fabric
     - SDWebImage
-    - SwiftyJSON
     - ViewAnimator
 
 SPEC CHECKSUMS:
   Crashlytics: 915a7787b84f635fb2a81f92a90e265c2c413f76
   Fabric: a2917d3895e4c1569b9c3170de7320ea1b1e6661
   SDWebImage: 47e9b5b925cbce75946c23f0c42dd19464189af4
-  SwiftyJSON: c29297daf073d2aa016295d5809cdd68045c39b3
   ViewAnimator: 43c31539508d995ea2c5e98338211f7c009b358f
 
-PODFILE CHECKSUM: ada79140deca34665860ff950b1cd49b53254135
+PODFILE CHECKSUM: b2bb471c3a48a5612aa1cc6bda359fddd1156cbc
 
 COCOAPODS: 1.5.3


### PR DESCRIPTION
This PR targets #108. Removes `SwiftyJSON` dependency and parses objects using the `Decodable` protocol. 

There a few points to discuss before merging: 

### Safe approach to decoding objects  
Right now decoding an array of decodable elements throws an error if one of the explicitly set keys is not present on the JSON file. We can take an approach like the one described in [this article](http://kean.github.io/post/codable-tips-and-tricks) to avoid this from happening. 

### Date management ✅
I'm using `dateDecodingStrategy` for the decoders which might not be the best approach for parsing time as we have multiple `JSONDecoder` instances on our `HTTPService` subclasses. It would be better to handle date parsing directly on the object's `init(from: Decoder)` method. 

Fix: d0fc6b106abff62486764c9b954939ff4a9adc1d

### Networking errors
At the moment we're not accounting for parsing errors when making network requests. If the network request succeeds we assume that the parsing will too or that there is valid data always. This can end in unexpected behaviors if we don't handle the different cases correctly. I propose we use an error structure like the one above to respond to any possible outcome:

```swift 
enum ServiceError:  Error {
  case parsingError
  case noData
  case custom(Error)
  // ... add extra necessary cases.
}
```

### Retain Cycles 
After the 5f018b6d55bea9ca1de421e31dd89586b5706d9a commit where I added the `[unowned self]` definition for closures inside the `NewsService` class the CI started to fail due to trying to use self after it was deallocated. This means that there's a retain cycle stopping the view controller that owns an instance of news service to deinit when there is a network call going on. I recommend we target this using: [LifeTimeTracker](https://github.com/krzysztofzablocki/LifetimeTracker)