### PR TITLE
Feat network result

### DIFF
--- a/Canillitapp Widget/TodayViewController.swift
+++ b/Canillitapp Widget/TodayViewController.swift
@@ -50,7 +50,7 @@ class TodayViewController: UIViewController, NCWidgetProviding {
 
                 self.widgetLabel.attributedText = attributedText
 
-            case .failure(_):
+            case .failure:
                 guard let self = self else {
                     return
                 }

--- a/Common/services/HTTPService.swift
+++ b/Common/services/HTTPService.swift
@@ -12,6 +12,8 @@ enum Method {
     case DELETE, GET, POST, PUT
 }
 
+typealias HTTPResult = Result<(response: URLResponse?, data: Data?), Error>
+
 class HTTPService {
 
     func baseURL() -> String {
@@ -26,7 +28,7 @@ class HTTPService {
                  path: String,
                  params: [String: String]?,
                  headers: [String: String]? = nil,
-                 handler: ((_ result: Result <Data?, Error>) -> Void)?) -> URLSessionDataTask? {
+                 handler: ((_ result: HTTPResult) -> Void)?) -> URLSessionDataTask? {
 
         let url = URL(string: "\(baseURL())/\(path)")
         var request = URLRequest(url: url!)
@@ -56,13 +58,13 @@ class HTTPService {
             request.httpBody = httpBody.data(using: .utf8)
         }
 
-        let task = session.dataTask(with: request, completionHandler: {(data, _, error) in
+        let task = session.dataTask(with: request, completionHandler: {(data, response, error) in
             if let e = error {
                 handler?(.failure(e))
                 return
             }
 
-            handler?(.success(data))
+            handler?(.success((response: response, data: data)))
         })
 
         task.resume()

--- a/Common/services/HTTPService.swift
+++ b/Common/services/HTTPService.swift
@@ -56,7 +56,7 @@ class HTTPService {
             request.httpBody = httpBody.data(using: .utf8)
         }
 
-        let task = session.dataTask(with: request, completionHandler: {(data, response, error) in
+        let task = session.dataTask(with: request, completionHandler: {(data, _, error) in
             if let e = error {
                 handler?(.failure(e))
                 return

--- a/Common/services/HTTPService.swift
+++ b/Common/services/HTTPService.swift
@@ -26,8 +26,7 @@ class HTTPService {
                  path: String,
                  params: [String: String]?,
                  headers: [String: String]? = nil,
-                 success: ((_ result: Data?, _ response: URLResponse?) -> Void)?,
-                 fail: ((_ error: NSError) -> Void)?) -> URLSessionDataTask? {
+                 handler: ((_ result: Result <Data?, Error>) -> Void)?) -> URLSessionDataTask? {
 
         let url = URL(string: "\(baseURL())/\(path)")
         var request = URLRequest(url: url!)
@@ -59,11 +58,11 @@ class HTTPService {
 
         let task = session.dataTask(with: request, completionHandler: {(data, response, error) in
             if let e = error {
-                fail?(e as NSError)
+                handler?(.failure(e))
                 return
             }
 
-            success?(data, response)
+            handler?(.success(data))
         })
 
         task.resume()

--- a/Common/services/MockService.swift
+++ b/Common/services/MockService.swift
@@ -10,13 +10,12 @@ import Foundation
 
 class MockService {
 
-    func request(file: String, handler: ((_ result: Result <Data?, Error>) -> Void)?) {
-
+    func request(file: String, handler: ((_ result: HTTPResult) -> Void)?) {
         let path = Bundle.main.path(forResource: file, ofType: "json")
         let url = URL(fileURLWithPath: path!)
         let data = try? Data(contentsOf: url)
         DispatchQueue.main.async {
-            handler?(.success(data))
+            handler?(.success((nil, data)))
         }
     }
 }

--- a/Common/services/MockService.swift
+++ b/Common/services/MockService.swift
@@ -10,17 +10,13 @@ import Foundation
 
 class MockService {
 
-    func request(file: String,
-                 success: ((_ result: Data?, _ response: URLResponse?) -> Void)?,
-                 fail: ((_ error: NSError) -> Void)?) {
+    func request(file: String, handler: ((_ result: Result <Data?, Error>) -> Void)?) {
 
         let path = Bundle.main.path(forResource: file, ofType: "json")
         let url = URL(fileURLWithPath: path!)
-        do {
-            let data = try Data(contentsOf: url)
-            DispatchQueue.main.async(execute: {
-                success?(data, nil)
-            })
-        } catch {}
+        let data = try? Data(contentsOf: url)
+        DispatchQueue.main.async {
+            handler?(.success(data))
+        }
     }
 }

--- a/Common/services/NewsService.swift
+++ b/Common/services/NewsService.swift
@@ -12,151 +12,156 @@ import CloudKit
 // swiftlint:disable force_try
 class NewsService: HTTPService {
 
+//handler: ((Result <Data?, Error>) -> Void)?) -> URLSessionDataTask? {
+
     func requestFromCategory (_ categoryId: String,
                               page: Int = 1,
-                              success: ((_ result: [News]?) -> Void)?,
-                              fail: ((_ error: NSError) -> Void)?) {
-
-        let successBlock: (_ result: Data?, _ response: URLResponse?) -> Void = {(data, response) in
-            guard let d = data else {
-                return
-            }
-
-            let res = try? News.decodeArrayOfNews(from: d)
-
-            DispatchQueue.main.async(execute: {
-                success?(res)
-            })
-        }
-
-        let failBlock: (_ error: NSError) -> Void = { (e) in
-            DispatchQueue.main.async(execute: {
-                fail?(e as NSError)
-            })
-        }
+                              handler: ((_ result: Result <[News]?, Error>) -> Void)?) {
 
         let path = "news/category/\(categoryId)?page=\(page)"
-        _ = request(method: .GET, path: path, params: nil, success: successBlock, fail: failBlock)
+
+        let handler: ((Result <Data?, Error>) -> Void) = { result in
+            switch result {
+            case .success(let data):
+                guard let d = data else {
+                    handler?(.success(nil))
+                    return
+                }
+
+                let res = try? News.decodeArrayOfNews(from: d)
+
+                DispatchQueue.main.async(execute: {
+                    handler?(.success(res))
+                })
+
+            case .failure(let error):
+                handler?(.failure(error))
+                return
+            }
+        }
+
+        _ = request(method: .GET, path: path, params: nil, handler: handler)
     }
 
     func requestPopularNews (page: Int = 1,
-                             success: ((_ result: [News]?) -> Void)?,
-                             fail: ((_ error: NSError) -> Void)?) {
+                             handler: ((_ result: Result <[News]?, Error>) -> Void)?) {
 
-        let successBlock: (_ result: Data?, _ response: URLResponse?) -> Void = {(data, response) in
-            guard let d = data else {
-                return
-            }
-
-            let res = try? News.decodeArrayOfNews(from: d)
-
-            DispatchQueue.main.async(execute: {
-                success?(res)
-            })
-        }
-
-        let failBlock: (_ error: NSError) -> Void = { (e) in
-            DispatchQueue.main.async(execute: {
-                fail?(e as NSError)
-            })
-        }
-
-        if ProcessInfo.processInfo.arguments.contains("mockRequests") {
-            let mockService = MockService()
-            _ = mockService.request(file: "GET-popular",
-                                    success: successBlock,
-                                    fail: failBlock)
-            return
-        }
+//        if ProcessInfo.processInfo.arguments.contains("mockRequests") {
+//            let mockService = MockService()
+//            _ = mockService.request(file: "GET-popular",
+//                                    success: successBlock,
+//                                    fail: failBlock)
+//            return
+//        }
 
         let path = "popular?page=\(page)"
-        _ = request(method: .GET, path: path, params: nil, success: successBlock, fail: failBlock)
+
+        let handler: ((Result <Data?, Error>) -> Void) = { result in
+            switch result {
+            case .success(let data):
+                guard let d = data else {
+                    handler?(.success(nil))
+                    return
+                }
+
+                let res = try? News.decodeArrayOfNews(from: d)
+
+                DispatchQueue.main.async(execute: {
+                    handler?(.success(res))
+                })
+            case .failure(let error):
+                handler?(.failure(error))
+            }
+        }
+
+        _ = request(method: .GET, path: path, params: nil, handler: handler)
     }
 
     func requestRecentNewsWithDate (_ date: Date,
-                                    success: ((_ result: [News]?) -> Void)?,
-                                    fail: ((_ error: NSError) -> Void)?) {
+                                    handler: ((_ result: Result <[News]?, Error>) -> Void)?) {
 
         let calendar = Calendar.current
         let components = (calendar as NSCalendar).components([.day, .month, .year], from: date)
 
         let datePath = String(format: "%d-%02d-%02d", components.year!, components.month!, components.day!)
 
-        let successBlock: (_ result: Data?, _ response: URLResponse?) -> Void = {(data, response) in
-            guard let d = data else {
-                return
+//        if ProcessInfo.processInfo.arguments.contains("mockRequests") {
+//            let mockService = MockService()
+//            _ = mockService.request(file: "GET-recent",
+//                                    success: successBlock,
+//                                    fail: failBlock)
+//            return
+//        }
+
+        let handler: ((Result <Data?, Error>) -> Void) = { result in
+            switch result {
+            case .success(let data):
+                guard let d = data else {
+                    handler?(.success(nil))
+                    return
+                }
+
+                let res = try? News.decodeArrayOfNews(from: d)
+
+                DispatchQueue.main.async(execute: {
+                    handler?(.success(res))
+                })
+            case .failure(let error):
+                handler?(.failure(error))
             }
-
-            let res = try? News.decodeArrayOfNews(from: d)
-
-            DispatchQueue.main.async(execute: {
-                success?(res)
-            })
         }
 
-        let failBlock: (_ error: NSError) -> Void = { (e) in
-            DispatchQueue.main.async(execute: {
-                fail?(e as NSError)
-            })
-        }
-
-        if ProcessInfo.processInfo.arguments.contains("mockRequests") {
-            let mockService = MockService()
-            _ = mockService.request(file: "GET-recent",
-                                    success: successBlock,
-                                    fail: failBlock)
-            return
-        }
-
-        _ = request(method: .GET, path: "latest/\(datePath)", params: nil, success: successBlock, fail: failBlock)
+        _ = request(method: .GET, path: "latest/\(datePath)", params: nil, handler: handler)
     }
 
     func requestTrendingTopicsWithDate (_ date: Date,
                                         count: Int,
-                                        success: ((_ result: TopicList?) -> Void)?,
-                                        fail: ((_ error: NSError) -> Void)?) -> URLSessionDataTask? {
+                                        handler: ((_ result: Result <TopicList?, Error>) -> Void)?) -> URLSessionDataTask? {
 
         let calendar = Calendar.current
         let components = (calendar as NSCalendar).components([.day, .month, .year], from: date)
 
         let datePath = String(format: "%d-%02d-%02d", components.year!, components.month!, components.day!)
 
-        let successBlock: (_ result: Data?, _ response: URLResponse?) -> Void = {(data, response) in
-            guard let d = data else {
-                return
+//        if ProcessInfo.processInfo.arguments.contains("mockRequests") {
+//            let mockService = MockService()
+//            _ = mockService.request(file: "GET-trending",
+//                                    success: successBlock,
+//                                    fail: failBlock)
+//            return nil
+//        }
+
+        let handler: ((Result <Data?, Error>) -> Void) = { result in
+            switch result {
+            case .success(let data):
+                guard let d = data else {
+                    handler?(.success(nil))
+                    return
+                }
+
+                let res = try! JSONDecoder().decode(TopicList.self, from: d)
+
+                DispatchQueue.main.async(execute: {
+                    handler?(.success(res))
+                })
+
+            case .failure(let error):
+                handler?(.failure(error))
             }
-
-            let res = try! JSONDecoder().decode(TopicList.self, from: d)
-
-            DispatchQueue.main.async(execute: {
-                success?(res)
-            })
         }
 
-        let failBlock: (_ error: NSError) -> Void = { (e) in
-            DispatchQueue.main.async(execute: {
-                fail?(e as NSError)
-            })
-        }
+        let task = request(
+            method: .GET,
+            path: "trending/\(datePath)/\(count)",
+            params: nil,
+            handler: handler
+        )
 
-        if ProcessInfo.processInfo.arguments.contains("mockRequests") {
-            let mockService = MockService()
-            _ = mockService.request(file: "GET-trending",
-                                    success: successBlock,
-                                    fail: failBlock)
-            return nil
-        }
-
-        return request(method: .GET,
-                       path: "trending/\(datePath)/\(count)",
-                       params: nil,
-                       success: successBlock,
-                       fail: failBlock)!
+        return task
     }
 
     func searchNews(_ text: String,
-                    success: ((_ result: [News]?) -> Void)?,
-                    fail: ((_ error: NSError) -> Void)?) -> URLSessionDataTask? {
+                    handler: ((_ result: Result <[News]?, Error>) -> Void)?) -> URLSessionDataTask? {
 
         let group = DispatchGroup()
 
@@ -164,31 +169,13 @@ class NewsService: HTTPService {
             return nil
         }
 
-        let successBlock: (_ result: Data?, _ response: URLResponse?) -> Void = {(data, response) in
-            guard let d = data else {
-                return
-            }
-
-            let res = try? News.decodeArrayOfNews(from: d)
-
-            DispatchQueue.main.async(execute: {
-                success?(res)
-            })
-        }
-
-        let failBlock: (_ error: NSError) -> Void = { (e) in
-            DispatchQueue.main.async(execute: {
-                fail?(e as NSError)
-            })
-        }
-
-        if ProcessInfo.processInfo.arguments.contains("mockRequests") {
-            let mockService = MockService()
-            _ = mockService.request(file: "GET-search",
-                                    success: successBlock,
-                                    fail: failBlock)
-            return nil
-        }
+//        if ProcessInfo.processInfo.arguments.contains("mockRequests") {
+//            let mockService = MockService()
+//            _ = mockService.request(file: "GET-search",
+//                                    success: successBlock,
+//                                    fail: failBlock)
+//            return nil
+//        }
 
         var headers: [String: String] = [:]
 
@@ -215,88 +202,92 @@ class NewsService: HTTPService {
         }
 
         group.wait()
-        return self.request(
-                        method: .GET,
-                        path: "search/\(encodedText)",
-                        params: nil,
-                        headers: headers,
-                        success: successBlock,
-                        fail: failBlock
-                )
+
+        let handler: ((Result <Data?, Error>) -> Void) = { result in
+            switch result {
+            case .success(let data):
+                guard let d = data else {
+                    handler?(.success(nil))
+                    return
+                }
+
+                let res = try? News.decodeArrayOfNews(from: d)
+
+                DispatchQueue.main.async(execute: {
+                    handler?(.success(res))
+                })
+            case .failure(let error):
+                handler?(.failure(error))
+            }
+        }
+
+        let task = self.request(method: .GET, path: "search/\(encodedText)", params: nil, handler: handler)
+        return task
     }
 
-    func fetchTrendingTerms(success: ((_ result: [TrendingTerm]) -> Void)?,
-                            fail: ((_ error: NSError) -> Void)?) {
+    func fetchTrendingTerms(handler: ((_ result: Result <[TrendingTerm]?, Error>) -> Void)?) {
 
-        let successBlock: (_ result: Data?, _ response: URLResponse?) -> Void = {( data, response) in
-            guard let data = data else {
-                return
+//        if ProcessInfo.processInfo.arguments.contains("mockRequests") {
+//            let mockService = MockService()
+//            _ = mockService.request(file: "GET-search-trending",
+//                                    success: successBlock,
+//                                    fail: failBlock)
+//            return
+//        }
+
+        let handler: ((Result <Data?, Error>) -> Void) = { result in
+            switch result {
+            case .success(let data):
+                guard let d = data else {
+                    handler?(.success(nil))
+                    return
+                }
+
+                let res = (try? JSONDecoder().decode([TrendingTerm].self, from: d)) ?? [TrendingTerm]()
+
+                DispatchQueue.main.async(execute: {
+                    handler?(.success(res))
+                })
+            case .failure(let error):
+                handler?(.failure(error))
             }
-
-            let terms = (try? JSONDecoder().decode([TrendingTerm].self, from: data)) ?? [TrendingTerm]()
-
-            DispatchQueue.main.async(execute: {
-                success?(terms)
-            })
         }
 
-        let failBlock: (_ error: NSError) -> Void = { (e) in
-            DispatchQueue.main.async(execute: {
-                fail?(e as NSError)
-            })
-        }
-
-        if ProcessInfo.processInfo.arguments.contains("mockRequests") {
-            let mockService = MockService()
-            _ = mockService.request(file: "GET-search-trending",
-                                    success: successBlock,
-                                    fail: failBlock)
-            return
-        }
-
-        _ = request(
-            method: .GET,
-            path: "search/trending/",
-            params: nil,
-            success: successBlock,
-            fail: failBlock
-        )
+        _ = request(method: .GET, path: "search/trending/", params: nil, handler: handler)
     }
 
     @discardableResult
-    func fetchTags(tag: String, success: ((_ result: [Tag]) -> Void)?,
-                   fail: ((_ error: NSError) -> Void)?) -> URLSessionDataTask? {
+    func fetchTags(tag: String,
+                   handler: ((_ result: Result <[Tag]?, Error>) -> Void)?) -> URLSessionDataTask? {
 
-        let successBlock: (_ result: Data?, _ response: URLResponse?) -> Void = {( data, response) in
-            guard let data = data else { return }
-            let decoder = JSONDecoder()
-            let tags = try? decoder.decode([Tag].self, from: data)
-            DispatchQueue.main.async(execute: {
-                success?(tags ?? [Tag]())
-            })
-        }
+//        if ProcessInfo.processInfo.arguments.contains("mockRequests") {
+//            let mockService = MockService()
+//            _ = mockService.request(file: "GET-search-term",
+//                                    success: successBlock,
+//                                    fail: failBlock)
+//            return nil
+//        }
 
-        let failBlock: (_ error: NSError) -> Void = { (e) in
-            DispatchQueue.main.async(execute: {
-                fail?(e as NSError)
-            })
-        }
+        let handler: ((Result <Data?, Error>) -> Void) = { result in
+            switch result {
+            case .success(let data):
+                guard let d = data else {
+                    handler?(.success(nil))
+                    return
+                }
 
-        if ProcessInfo.processInfo.arguments.contains("mockRequests") {
-            let mockService = MockService()
-            _ = mockService.request(file: "GET-search-term",
-                                    success: successBlock,
-                                    fail: failBlock)
-            return nil
+                let res = try? JSONDecoder().decode([Tag].self, from: d)
+
+                DispatchQueue.main.async(execute: {
+                    handler?(.success(res))
+                })
+            case .failure(let error):
+                handler?(.failure(error))
+            }
         }
 
         let encodedTag = tag.addingPercentEncoding(withAllowedCharacters: .urlHostAllowed) ?? String()
-        return request(
-            method: .GET,
-            path: "tags/\(encodedTag)",
-            params: nil,
-            success: successBlock,
-            fail: failBlock
-        )
+        let task = request(method: .GET, path: "tags/\(encodedTag)", params: nil, handler: handler)
+        return task
     }
 }

--- a/Common/services/NewsService.swift
+++ b/Common/services/NewsService.swift
@@ -44,7 +44,7 @@ class NewsService: HTTPService {
     }
 
     func requestPopularNews (page: Int = 1,
-                             handler: ((_ result: Result <[News]?, Error>) -> Void)?) {
+                             handler: ((_ result: Result <[News], Error>) -> Void)?) {
 
 //        if ProcessInfo.processInfo.arguments.contains("mockRequests") {
 //            let mockService = MockService()
@@ -60,11 +60,11 @@ class NewsService: HTTPService {
             switch result {
             case .success(let data):
                 guard let d = data else {
-                    handler?(.success(nil))
+                    handler?(.success([]))
                     return
                 }
 
-                let res = try? News.decodeArrayOfNews(from: d)
+                let res = (try? News.decodeArrayOfNews(from: d)) ?? []
 
                 DispatchQueue.main.async(execute: {
                     handler?(.success(res))
@@ -161,7 +161,7 @@ class NewsService: HTTPService {
     }
 
     func searchNews(_ text: String,
-                    handler: ((_ result: Result <[News]?, Error>) -> Void)?) -> URLSessionDataTask? {
+                    handler: ((_ result: Result <[News], Error>) -> Void)?) -> URLSessionDataTask? {
 
         let group = DispatchGroup()
 
@@ -207,11 +207,11 @@ class NewsService: HTTPService {
             switch result {
             case .success(let data):
                 guard let d = data else {
-                    handler?(.success(nil))
+                    handler?(.success([]))
                     return
                 }
 
-                let res = try? News.decodeArrayOfNews(from: d)
+                let res = (try? News.decodeArrayOfNews(from: d)) ?? []
 
                 DispatchQueue.main.async(execute: {
                     handler?(.success(res))
@@ -225,7 +225,7 @@ class NewsService: HTTPService {
         return task
     }
 
-    func fetchTrendingTerms(handler: ((_ result: Result <[TrendingTerm]?, Error>) -> Void)?) {
+    func fetchTrendingTerms(handler: ((_ result: Result <[TrendingTerm], Error>) -> Void)?) {
 
 //        if ProcessInfo.processInfo.arguments.contains("mockRequests") {
 //            let mockService = MockService()
@@ -239,7 +239,7 @@ class NewsService: HTTPService {
             switch result {
             case .success(let data):
                 guard let d = data else {
-                    handler?(.success(nil))
+                    handler?(.success([]))
                     return
                 }
 

--- a/Common/services/NewsService.swift
+++ b/Common/services/NewsService.swift
@@ -16,7 +16,7 @@ class NewsService: HTTPService {
 
     func requestFromCategory (_ categoryId: String,
                               page: Int = 1,
-                              handler: ((_ result: Result <[News]?, Error>) -> Void)?) {
+                              handler: ((_ result: Result <[News], Error>) -> Void)?) {
 
         let path = "news/category/\(categoryId)?page=\(page)"
 
@@ -24,11 +24,11 @@ class NewsService: HTTPService {
             switch result {
             case .success(let data):
                 guard let d = data else {
-                    handler?(.success(nil))
+                    handler?(.success([News]()))
                     return
                 }
 
-                let res = try? News.decodeArrayOfNews(from: d)
+                let res = (try? News.decodeArrayOfNews(from: d)) ?? [News]()
 
                 DispatchQueue.main.async(execute: {
                     handler?(.success(res))
@@ -78,7 +78,7 @@ class NewsService: HTTPService {
     }
 
     func requestRecentNewsWithDate (_ date: Date,
-                                    handler: ((_ result: Result <[News]?, Error>) -> Void)?) {
+                                    handler: ((_ result: Result <[News], Error>) -> Void)?) {
 
         let calendar = Calendar.current
         let components = (calendar as NSCalendar).components([.day, .month, .year], from: date)
@@ -97,11 +97,11 @@ class NewsService: HTTPService {
             switch result {
             case .success(let data):
                 guard let d = data else {
-                    handler?(.success(nil))
+                    handler?(.success([News]()))
                     return
                 }
 
-                let res = try? News.decodeArrayOfNews(from: d)
+                let res = (try? News.decodeArrayOfNews(from: d)) ?? [News]()
 
                 DispatchQueue.main.async(execute: {
                     handler?(.success(res))
@@ -258,7 +258,7 @@ class NewsService: HTTPService {
 
     @discardableResult
     func fetchTags(tag: String,
-                   handler: ((_ result: Result <[Tag]?, Error>) -> Void)?) -> URLSessionDataTask? {
+                   handler: ((_ result: Result <[Tag], Error>) -> Void)?) -> URLSessionDataTask? {
 
 //        if ProcessInfo.processInfo.arguments.contains("mockRequests") {
 //            let mockService = MockService()
@@ -272,11 +272,11 @@ class NewsService: HTTPService {
             switch result {
             case .success(let data):
                 guard let d = data else {
-                    handler?(.success(nil))
+                    handler?(.success([Tag]()))
                     return
                 }
 
-                let res = try? JSONDecoder().decode([Tag].self, from: d)
+                let res = (try? JSONDecoder().decode([Tag].self, from: d)) ?? [Tag]()
 
                 DispatchQueue.main.async(execute: {
                     handler?(.success(res))

--- a/Common/services/NewsService.swift
+++ b/Common/services/NewsService.swift
@@ -18,10 +18,10 @@ class NewsService: HTTPService {
 
         let path = "news/category/\(categoryId)?page=\(page)"
 
-        let httpHandler: ((Result <Data?, Error>) -> Void) = { result in
+        let httpHandler: ((HTTPResult) -> Void) = { result in
             switch result {
-            case .success(let data):
-                guard let d = data else {
+            case .success(let success):
+                guard let d = success.data else {
                     handler?(.success([News]()))
                     return
                 }
@@ -44,10 +44,10 @@ class NewsService: HTTPService {
     func requestPopularNews (page: Int = 1,
                              handler: ((_ result: Result <[News], Error>) -> Void)?) {
 
-        let httpHandler: ((Result <Data?, Error>) -> Void) = { result in
+        let httpHandler: ((HTTPResult) -> Void) = { result in
             switch result {
-            case .success(let data):
-                guard let d = data else {
+            case .success(let success):
+                guard let d = success.data else {
                     handler?(.success([]))
                     return
                 }
@@ -80,10 +80,10 @@ class NewsService: HTTPService {
 
         let datePath = String(format: "%d-%02d-%02d", components.year!, components.month!, components.day!)
 
-        let httpHandler: ((Result <Data?, Error>) -> Void) = { result in
+        let httpHandler: ((HTTPResult) -> Void) = { result in
             switch result {
-            case .success(let data):
-                guard let d = data else {
+            case .success(let success):
+                guard let d = success.data else {
                     handler?(.success([News]()))
                     return
                 }
@@ -116,15 +116,15 @@ class NewsService: HTTPService {
 
         let datePath = String(format: "%d-%02d-%02d", components.year!, components.month!, components.day!)
 
-        let httpHandler: ((Result <Data?, Error>) -> Void) = { result in
+        let httpHandler: ((HTTPResult) -> Void) = { result in
             switch result {
-            case .success(let data):
-                guard let d = data else {
+            case .success(let success):
+                guard let d = success.data else {
                     handler?(.success(nil))
                     return
                 }
 
-                let res = try! JSONDecoder().decode(TopicList.self, from: d)
+                let res = try? JSONDecoder().decode(TopicList.self, from: d)
 
                 DispatchQueue.main.async(execute: {
                     handler?(.success(res))
@@ -160,10 +160,10 @@ class NewsService: HTTPService {
             return nil
         }
 
-        let httpHandler: ((Result <Data?, Error>) -> Void) = { result in
+        let httpHandler: ((HTTPResult) -> Void) = { result in
             switch result {
-            case .success(let data):
-                guard let d = data else {
+            case .success(let success):
+                guard let d = success.data else {
                     handler?(.success([]))
                     return
                 }
@@ -216,10 +216,10 @@ class NewsService: HTTPService {
 
     func fetchTrendingTerms(handler: ((_ handler: Result <[TrendingTerm], Error>) -> Void)?) {
 
-        let httpHandler: ((Result <Data?, Error>) -> Void) = { result in
+        let httpHandler: ((HTTPResult) -> Void) = { result in
             switch result {
-            case .success(let data):
-                guard let d = data else {
+            case .success(let success):
+                guard let d = success.data else {
                     handler?(.success([]))
                     return
                 }
@@ -247,10 +247,10 @@ class NewsService: HTTPService {
     func fetchTags(tag: String,
                    handler: ((_ handler: Result <[Tag], Error>) -> Void)?) -> URLSessionDataTask? {
 
-        let httpHandler: ((Result <Data?, Error>) -> Void) = { result in
+        let httpHandler: ((HTTPResult) -> Void) = { result in
             switch result {
-            case .success(let data):
-                guard let d = data else {
+            case .success(let success):
+                guard let d = success.data else {
                     handler?(.success([Tag]()))
                     return
                 }

--- a/Headlines/AppDelegate.swift
+++ b/Headlines/AppDelegate.swift
@@ -147,7 +147,7 @@ class AppDelegate: UIResponder,
 
                 vc.present(navController, animated: true, completion: nil)
 
-            case .failure(_):
+            case .failure:
                 hud.dismiss()
             }
         }

--- a/Headlines/src/Categories/UIImageEffects.swift
+++ b/Headlines/src/Categories/UIImageEffects.swift
@@ -92,19 +92,19 @@ import UIKit
 import Accelerate
 
 public extension UIImage {
-    public func applyLightEffect() -> UIImage? {
+    func applyLightEffect() -> UIImage? {
         return applyBlurWithRadius(30, tintColor: UIColor(white: 1.0, alpha: 0.3), saturationDeltaFactor: 1.8)
     }
 
-    public func applyExtraLightEffect() -> UIImage? {
+    func applyExtraLightEffect() -> UIImage? {
         return applyBlurWithRadius(20, tintColor: UIColor(white: 0.97, alpha: 0.82), saturationDeltaFactor: 1.8)
     }
 
-    public func applyDarkEffect() -> UIImage? {
+    func applyDarkEffect() -> UIImage? {
         return applyBlurWithRadius(20, tintColor: UIColor(white: 0.11, alpha: 0.73), saturationDeltaFactor: 1.8)
     }
 
-    public func applyTintEffectWithColor(_ tintColor: UIColor) -> UIImage? {
+    func applyTintEffectWithColor(_ tintColor: UIColor) -> UIImage? {
         let effectColorAlpha: CGFloat = 0.6
         var effectColor = tintColor
 
@@ -128,10 +128,11 @@ public extension UIImage {
         return applyBlurWithRadius(10, tintColor: effectColor, saturationDeltaFactor: -1.0, maskImage: nil)
     }
 
-    public func applyBlurWithRadius(_ blurRadius: CGFloat,
-                                    tintColor: UIColor?,
-                                    saturationDeltaFactor: CGFloat,
-                                    maskImage: UIImage? = nil) -> UIImage? {
+    func applyBlurWithRadius(_ blurRadius: CGFloat,
+                             tintColor: UIColor?,
+                             saturationDeltaFactor: CGFloat,
+                             maskImage: UIImage? = nil) -> UIImage? {
+
         // Check pre-conditions.
         if size.width < 1 || size.height < 1 {
             print("*** error: invalid size: \(size.width) x \(size.height). Both dimensions must be >= 1: \(self)")
@@ -152,7 +153,7 @@ public extension UIImage {
         var effectImage = self
 
         let hasBlur = blurRadius > FLTEPSILON
-        let hasSaturationChange = fabs(saturationDeltaFactor - 1.0) > FLTEPSILON
+        let hasSaturationChange = abs(saturationDeltaFactor - 1.0) > FLTEPSILON
 
         if hasBlur || hasSaturationChange {
             func createEffectBuffer(_ context: CGContext) -> vImage_Buffer {

--- a/Headlines/src/Controllers/NewsTableViewController+FetchNews.swift
+++ b/Headlines/src/Controllers/NewsTableViewController+FetchNews.swift
@@ -154,7 +154,7 @@ extension NewsTableViewController {
             case .success(let news):
                 self?.updateNews(news, mode)
 
-            case .failure(_):
+            case .failure:
                 // Stop pull to refresh animation (if needed)
                 if mode.shouldAnimatePullToRefresh() {
                     self?.endRefreshing()

--- a/Headlines/src/Controllers/NewsTableViewController+FetchNews.swift
+++ b/Headlines/src/Controllers/NewsTableViewController+FetchNews.swift
@@ -56,6 +56,59 @@ extension NewsTableViewController {
         fetch(mode: .reload)
     }
 
+    func updateNews(_ news: [News], _ mode: FetchMode) {
+
+        guard let tableView = tableView else {
+            return
+        }
+
+        // Stop pull to refresh animation (if needed)
+        if mode.shouldAnimatePullToRefresh() {
+            endRefreshing()
+        }
+
+        // If news are == 0, then we reached to the end
+        guard news.count > 0 else {
+            canFetchMoreNews = false
+            return
+        }
+
+        // Generate NewsCellViewModels from News
+        let viewModels = self.viewModels(from: news)
+
+        // Calculate indexpaths to update
+        let filteredNews = filterNews(viewModels)
+
+        let indexPaths = indexPathsToUpdate(
+            start: newsViewModels.count,
+            length: filteredNews.count
+        )
+
+        // Append all news to newsViewModels
+        newsViewModels.append(contentsOf: viewModels)
+
+        // Append filtered news and update our tableView
+        UIView.performWithoutAnimation {
+            tableView.beginUpdates()
+            filteredNewsViewModels.append(contentsOf: filteredNews)
+            tableView.insertRows(at: indexPaths, with: .none)
+            tableView.setContentOffset(tableView.contentOffset, animated: false)
+            tableView.endUpdates()
+        }
+
+        // Animate all cells appearing (if needed)
+        if mode.shouldAnimateCells() {
+            UIView.animate(
+                views: tableView.visibleCells,
+                animations: [AnimationType.from(direction: .right, offset: 10.0)],
+                animationInterval: 0.1
+            )
+        }
+
+        lastPage += 1
+        isFetchingNews = false
+    }
+
     func fetch(mode: FetchMode) {
 
         guard let newsDataSource = newsDataSource,
@@ -69,59 +122,6 @@ extension NewsTableViewController {
         // Animate pull to refresh (if needed)
         if mode.shouldAnimatePullToRefresh() {
             startRefreshing()
-        }
-
-        let success: (([News]) -> Void) = { [weak self] news in
-
-            guard let strongSelf = self, let tableView = strongSelf.tableView else {
-                return
-            }
-
-            // Stop pull to refresh animation (if needed)
-            if mode.shouldAnimatePullToRefresh() {
-                strongSelf.endRefreshing()
-            }
-
-            // If news are == 0, then we reached to the end
-            guard news.count > 0 else {
-                strongSelf.canFetchMoreNews = false
-                return
-            }
-
-            // Generate NewsCellViewModels from News
-            let viewModels = strongSelf.viewModels(from: news)
-
-            // Calculate indexpaths to update
-            let filteredNews = strongSelf.filterNews(viewModels)
-
-            let indexPaths = strongSelf.indexPathsToUpdate(
-                start: strongSelf.newsViewModels.count,
-                length: filteredNews.count
-            )
-
-            // Append all news to newsViewModels
-            strongSelf.newsViewModels.append(contentsOf: viewModels)
-
-            // Append filtered news and update our tableView
-            UIView.performWithoutAnimation {
-                tableView.beginUpdates()
-                strongSelf.filteredNewsViewModels.append(contentsOf: filteredNews)
-                tableView.insertRows(at: indexPaths, with: .none)
-                tableView.setContentOffset(tableView.contentOffset, animated: false)
-                tableView.endUpdates()
-            }
-
-            // Animate all cells appearing (if needed)
-            if mode.shouldAnimateCells() {
-                UIView.animate(
-                    views: tableView.visibleCells,
-                    animations: [AnimationType.from(direction: .right, offset: 10.0)],
-                    animationInterval: 0.1
-                )
-            }
-
-            strongSelf.lastPage += 1
-            strongSelf.isFetchingNews = false
         }
 
         let fail: ((NSError?) -> Void) = { [weak self] _ in
@@ -149,7 +149,21 @@ extension NewsTableViewController {
             break
         }
 
-        newsDataSource.fetchNews(page: lastPage, success: success, fail: fail)
+        let handler: ((Result <[News], Error>) -> Void) = { [weak self] result in
+            switch result {
+            case .success(let news):
+                self?.updateNews(news, mode)
+
+            case .failure(_):
+                // Stop pull to refresh animation (if needed)
+                if mode.shouldAnimatePullToRefresh() {
+                    self?.endRefreshing()
+                }
+
+                self?.isFetchingNews = false
+            }
+        }
+        newsDataSource.fetchNews(page: lastPage, handler: handler)
     }
 }
 

--- a/Headlines/src/Controllers/NewsTableViewController+FetchNews.swift
+++ b/Headlines/src/Controllers/NewsTableViewController+FetchNews.swift
@@ -124,20 +124,6 @@ extension NewsTableViewController {
             startRefreshing()
         }
 
-        let fail: ((NSError?) -> Void) = { [weak self] _ in
-
-            guard let strongSelf = self else {
-                return
-            }
-
-            // Stop pull to refresh animation (if needed)
-            if mode.shouldAnimatePullToRefresh() {
-                strongSelf.endRefreshing()
-            }
-
-            strongSelf.isFetchingNews = false
-        }
-
         switch mode {
         case .reload:
             lastPage = 1

--- a/Headlines/src/Controllers/NewsTableViewController+Safari.swift
+++ b/Headlines/src/Controllers/NewsTableViewController+Safari.swift
@@ -17,7 +17,7 @@ extension NewsTableViewController {
             return
         }
 
-        contentViewsService.postContentView(news.identifier, context: contextFrom, success: nil, fail: nil)
+        contentViewsService.postContentView(news.identifier, context: contextFrom, handler: nil)
     }
 
     func openNews(_ news: News) {

--- a/Headlines/src/Controllers/NewsTableViewController.swift
+++ b/Headlines/src/Controllers/NewsTableViewController.swift
@@ -45,7 +45,7 @@ class NewsTableViewController: UIViewController {
     var isFetchingNews: Bool = false
     var canFetchMoreNews: Bool = true
 
-    func showControllerWithError(_ error: NSError) {
+    func showControllerWithError(_ error: Error) {
         let okAction = UIAlertAction(title: "Ok", style: .default, handler: nil)
         let alertController = UIAlertController(title: "Sorry",
                                                 message: error.localizedDescription,

--- a/Headlines/src/Controllers/Search/NewsSearchStateController.swift
+++ b/Headlines/src/Controllers/Search/NewsSearchStateController.swift
@@ -37,9 +37,15 @@ class NewsSearchStateController: UIViewController, UISearchResultsUpdating {
         if stateViewController.shownViewController is NewsSearchViewController {
             stateViewController.transition(to: .loading)
         }
-        dataTask = service.fetchTags(tag: text, success: { [unowned self] tags in
-            self.render(tags: tags, searchedTerm: text)
-            }, fail: nil)
+
+        dataTask = service.fetchTags(tag: text, handler: { [weak self] result in
+            switch result {
+            case .success(let tags):
+                self?.render(tags: tags, searchedTerm: text)
+            case .failure(let _):
+                print("Fail at updateSearchResults")
+            }
+        })
     }
 
     private func render(news: [News]?) {
@@ -66,23 +72,23 @@ class NewsSearchStateController: UIViewController, UISearchResultsUpdating {
         dataTask?.cancel()
         stateViewController.transition(to: .loading)
 
-        self.dataTask = self.service.searchNews(
-            term,
-            success: self.render,
-            fail: self.error
-        )
+        self.dataTask = self.service.searchNews(term, handler: { [weak self] result in
+            switch result {
+            case .success(let news):
+                self?.render(news: news)
+            case .failure(let err):
+                self?.error(err)
+            }
+        })
     }
 
-    private func error(_ error: NSError) {
-        guard error.code == NSURLErrorCancelled else {
-            let alert = UIAlertController(
-                title: "Sorry",
-                message: error.localizedDescription,
-                preferredStyle: .alert
-            )
-            alert.addAction(UIAlertAction(title: "Ok", style: .default, handler: nil))
-            present(alert, animated: true, completion: nil)
-            return
-        }
+    private func error(_ error: Error) {
+        let alert = UIAlertController(
+            title: "Sorry",
+            message: error.localizedDescription,
+            preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(title: "Ok", style: .default, handler: nil))
+        present(alert, animated: true, completion: nil)
     }
 }

--- a/Headlines/src/Controllers/Search/NewsSearchStateController.swift
+++ b/Headlines/src/Controllers/Search/NewsSearchStateController.swift
@@ -42,7 +42,7 @@ class NewsSearchStateController: UIViewController, UISearchResultsUpdating {
             switch result {
             case .success(let tags):
                 self?.render(tags: tags, searchedTerm: text)
-            case .failure(let _):
+            case .failure:
                 print("Fail at updateSearchResults")
             }
         })

--- a/Headlines/src/Controllers/Search/TrendingSearchViewController.swift
+++ b/Headlines/src/Controllers/Search/TrendingSearchViewController.swift
@@ -41,7 +41,7 @@ class TrendingSearchViewController: UITableViewController {
                     self?.refreshControl?.endRefreshing()
                 }
 
-            case .failure(let error):
+            case .failure:
                 if !ProcessInfo.processInfo.arguments.contains("mockRequests") {
                     self?.refreshControl?.endRefreshing()
                 }

--- a/Headlines/src/Controllers/Search/TrendingSearchViewController.swift
+++ b/Headlines/src/Controllers/Search/TrendingSearchViewController.swift
@@ -33,16 +33,22 @@ class TrendingSearchViewController: UITableViewController {
     }
 
     private func fetchTrending() {
-        service.fetchTrendingTerms(success: { [unowned self] in
-            self.terms = $0
-            if !ProcessInfo.processInfo.arguments.contains("mockRequests") {
-                self.refreshControl?.endRefreshing()
-            }
-            }, fail: { [unowned self] _ in
+        let handler: ((Result<[TrendingTerm], Error>) -> Void) = { [weak self] result in
+            switch result {
+            case .success(let terms):
+                self?.terms = terms
                 if !ProcessInfo.processInfo.arguments.contains("mockRequests") {
-                    self.refreshControl?.endRefreshing()
+                    self?.refreshControl?.endRefreshing()
                 }
-        })
+
+            case .failure(let error):
+                if !ProcessInfo.processInfo.arguments.contains("mockRequests") {
+                    self?.refreshControl?.endRefreshing()
+                }
+            }
+        }
+
+        service.fetchTrendingTerms(handler: handler)
     }
 
     // MARK: - UITableViewDataSource

--- a/Headlines/src/DataSources/CategoryNewsDataSource.swift
+++ b/Headlines/src/DataSources/CategoryNewsDataSource.swift
@@ -25,19 +25,7 @@ class CategoryNewsDataSource: NewsTableViewControllerDataSource {
         self.category = category
     }
 
-    func fetchNews(page: Int, success: ((_: [News]) -> Void)?, fail: ((_ error: NSError) -> Void)?) {
-        newsService.requestFromCategory(category.identifier, page: page, success: { (result) in
-            guard let r = result else {
-                let userInfo = [
-                    NSLocalizedDescriptionKey: "No data"
-                ]
-
-                let e = NSError(domain: "CategoryNewsDataSource", code: 1, userInfo: userInfo)
-                fail?(e)
-                return
-            }
-
-            success?(r)
-        }, fail: fail)
+    func fetchNews(page: Int, handler: ((_ result: Result <[News], Error>) -> Void)?) {
+        newsService.requestFromCategory(category.identifier, page: page, handler: handler)
     }
 }

--- a/Headlines/src/DataSources/NewsTableViewControllerDataSource.swift
+++ b/Headlines/src/DataSources/NewsTableViewControllerDataSource.swift
@@ -12,5 +12,5 @@ protocol NewsTableViewControllerDataSource {
     var shouldDisplayPullToRefreshControl: Bool { get }
     var isFilterEnabled: Bool { get }
     var isPaginationEnabled: Bool { get }
-    func fetchNews(page: Int, success: ((_: [News]) -> Void)?, fail: ((_ error: NSError) -> Void)?)
+    func fetchNews(page: Int, handler: ((_ result: Result <[News], Error>) -> Void)?)
 }

--- a/Headlines/src/DataSources/PopularNewsDataSource.swift
+++ b/Headlines/src/DataSources/PopularNewsDataSource.swift
@@ -21,22 +21,7 @@ class PopularNewsDataSource: NewsTableViewControllerDataSource {
 
     required init() {}
 
-    func fetchNews(page: Int, success: ((_: [News]) -> Void)?, fail: ((_ error: NSError) -> Void)?) {
-
-        let success: (([News]?) -> Void) = { result in
-            guard let r = result else {
-                let userInfo = [
-                    NSLocalizedDescriptionKey: "No data"
-                ]
-
-                let e = NSError(domain: "PopularNewsDataSource", code: 1, userInfo: userInfo)
-                fail?(e)
-                return
-            }
-
-            success?(r)
-        }
-
-        newsService.requestPopularNews(page: page, success: success, fail: fail)
+    func fetchNews(page: Int, handler: ((Result <[News], Error>) -> Void)?) {
+        newsService.requestPopularNews(page: page, handler: handler)
     }
 }

--- a/Headlines/src/DataSources/ProfileDataSource.swift
+++ b/Headlines/src/DataSources/ProfileDataSource.swift
@@ -90,9 +90,13 @@ class ProfileDataSource: NSObject, UICollectionViewDataSource {
 
         switch indexPath.section {
         case 0:
-            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "interest_cell", for: indexPath) as? LabelCollectionViewCell else {
-                return UICollectionViewCell()
+
+            guard let cell = collectionView.dequeueReusableCell(
+                withReuseIdentifier: "interest_cell",
+                for: indexPath) as? LabelCollectionViewCell else {
+                    return UICollectionViewCell()
             }
+
             let interest = interests[indexPath.row]
             cell.label.text = interest.name
             cell.label.textColor = UIColor.black
@@ -106,9 +110,13 @@ class ProfileDataSource: NSObject, UICollectionViewDataSource {
             return cell
 
         case 1:
-            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "reaction_cell", for: indexPath) as? ProfileReactionCollectionViewCell else {
-                return UICollectionViewCell()
+
+            guard let cell = collectionView.dequeueReusableCell(
+                withReuseIdentifier: "reaction_cell",
+                for: indexPath) as? ProfileReactionCollectionViewCell else {
+                    return UICollectionViewCell()
             }
+
             let reaction = reactions[indexPath.row]
             cell.emojiLabel.text = reaction.reaction
 

--- a/Headlines/src/DataSources/RecentNewsDataSource.swift
+++ b/Headlines/src/DataSources/RecentNewsDataSource.swift
@@ -19,19 +19,7 @@ class RecentNewsDataSource: NewsTableViewControllerDataSource {
 
     var isPaginationEnabled = false
 
-    func fetchNews(page: Int, success: (([News]) -> Void)?, fail: ((NSError) -> Void)?) {
-        newsService.requestRecentNewsWithDate(Date(), success: { (result) in
-            guard let r = result else {
-                let userInfo = [
-                    NSLocalizedDescriptionKey: "No data"
-                ]
-
-                let e = NSError(domain: "RecentNewsDataSource", code: 1, userInfo: userInfo)
-                fail?(e)
-                return
-            }
-
-            success?(r)
-        }, fail: fail)
+    func fetchNews(page: Int, handler: ((_ result: Result <[News], Error>) -> Void)?) {
+        newsService.requestRecentNewsWithDate(Date(), handler: handler)
     }
 }

--- a/Headlines/src/Services/CategoriesService.swift
+++ b/Headlines/src/Services/CategoriesService.swift
@@ -12,10 +12,10 @@ class CategoriesService: HTTPService {
 
     func categoriesList (handler: ((_ result: Result <[Category]?, Error>) -> Void)?) {
 
-        let httpHandler: ((Result <Data?, Error>) -> Void) = { result in
+        let httpHandler: ((HTTPResult) -> Void) = { result in
             switch result {
-            case .success(let data):
-                guard let d = data else {
+            case .success(let success):
+                guard let d = success.data else {
                     handler?(.success(nil))
                     return
                 }

--- a/Headlines/src/Services/CategoriesService.swift
+++ b/Headlines/src/Services/CategoriesService.swift
@@ -10,35 +10,36 @@ import Foundation
 
 class CategoriesService: HTTPService {
 
-    func categoriesList (success: ((_ result: [Category]?) -> Void)?,
-                         fail: ((_ error: NSError) -> Void)?) {
+    func categoriesList (handler: ((_ result: Result <[Category]?, Error>) -> Void)?) {
 
-        let successBlock: (_ result: Data?, _ response: URLResponse?) -> Void = {(data, response) in
-            guard let d = data else {
+//        if ProcessInfo.processInfo.arguments.contains("mockRequests") {
+//            let mockService = MockService()
+//            _ = mockService.request(file: "GET-categories",
+//                                    success: successBlock,
+//                                    fail: failBlock)
+//            return
+//        }
+
+        let httpHandler: ((Result <Data?, Error>) -> Void) = { result in
+            switch result {
+            case .success(let data):
+                guard let d = data else {
+                    handler?(.success(nil))
+                    return
+                }
+
+                let res = try? JSONDecoder().decode([Category].self, from: d)
+
+                DispatchQueue.main.async(execute: {
+                    handler?(.success(res))
+                })
+
+            case .failure(let error):
+                handler?(.failure(error))
                 return
             }
-
-            let res = try? JSONDecoder().decode([Category].self, from: d)
-
-            DispatchQueue.main.async(execute: {
-                success?(res)
-            })
         }
 
-        let failBlock: (_ error: NSError) -> Void = { (e) in
-            DispatchQueue.main.async(execute: {
-                fail?(e as NSError)
-            })
-        }
-
-        if ProcessInfo.processInfo.arguments.contains("mockRequests") {
-            let mockService = MockService()
-            _ = mockService.request(file: "GET-categories",
-                                    success: successBlock,
-                                    fail: failBlock)
-            return
-        }
-
-        _ = request(method: .GET, path: "categories/", params: nil, success: successBlock, fail: failBlock)
+        _ = request(method: .GET, path: "categories/", params: nil, handler: httpHandler)
     }
 }

--- a/Headlines/src/Services/CategoriesService.swift
+++ b/Headlines/src/Services/CategoriesService.swift
@@ -12,14 +12,6 @@ class CategoriesService: HTTPService {
 
     func categoriesList (handler: ((_ result: Result <[Category]?, Error>) -> Void)?) {
 
-//        if ProcessInfo.processInfo.arguments.contains("mockRequests") {
-//            let mockService = MockService()
-//            _ = mockService.request(file: "GET-categories",
-//                                    success: successBlock,
-//                                    fail: failBlock)
-//            return
-//        }
-
         let httpHandler: ((Result <Data?, Error>) -> Void) = { result in
             switch result {
             case .success(let data):
@@ -38,6 +30,12 @@ class CategoriesService: HTTPService {
                 handler?(.failure(error))
                 return
             }
+        }
+
+        if ProcessInfo.processInfo.arguments.contains("mockRequests") {
+            let mockService = MockService()
+            _ = mockService.request(file: "GET-categories", handler: httpHandler)
+            return
         }
 
         _ = request(method: .GET, path: "categories/", params: nil, handler: httpHandler)

--- a/Headlines/src/Services/ContentViewsService.swift
+++ b/Headlines/src/Services/ContentViewsService.swift
@@ -17,7 +17,7 @@ class ContentViewsService: HTTPService {
 
     func postContentView(_ newsIdentifier: String,
                          context: ContentViewContextFrom,
-                         handler: ((Result<String?, Error>) -> Void)?) {
+                         handler: ((Result<URLResponse?, Error>) -> Void)?) {
 
         let container = CKContainer.default()
         container.fetchUserRecordID { [weak self] (recordId, error) in
@@ -42,11 +42,11 @@ class ContentViewsService: HTTPService {
                 "context_from": context.rawValue
                 ]
 
-            let httpHandler: ((Result <Data?, Error>) -> Void) = { result in
+            let httpHandler: ((HTTPResult) -> Void) = { result in
                 switch result {
-                case .success:
+                case .success(let success):
                     DispatchQueue.main.async(execute: {
-                        handler?(.success(nil))
+                        handler?(.success(success.response))
                     })
 
                 case .failure(let error):

--- a/Headlines/src/Services/ContentViewsService.swift
+++ b/Headlines/src/Services/ContentViewsService.swift
@@ -17,13 +17,12 @@ class ContentViewsService: HTTPService {
 
     func postContentView(_ newsIdentifier: String,
                          context: ContentViewContextFrom,
-                         success: ((_ response: URLResponse?) -> Void)?,
-                         fail: ((_ error: Error) -> Void)?) {
+                         handler: ((Result<String?, Error>) -> Void)?) {
 
         let container = CKContainer.default()
-        container.fetchUserRecordID { (recordId, error) in
+        container.fetchUserRecordID { [weak self] (recordId, error) in
             if let err = error {
-                fail?(err)
+                handler?(.failure(err))
                 return
             }
 
@@ -32,20 +31,8 @@ class ContentViewsService: HTTPService {
                 let err = NSError(domain: "ContentViewsService",
                                   code: 1,
                                   userInfo: errUserInfo)
-                fail?(err)
+                handler?(.failure(err))
                 return
-            }
-
-            let successBlock: (_ result: Data?, _ response: URLResponse?) -> Void = {(data, response) in
-                DispatchQueue.main.async(execute: {
-                    success?(response)
-                })
-            }
-
-            let failBlock: (_ error: NSError) -> Void = { (e) in
-                DispatchQueue.main.async(execute: {
-                    fail?(e as NSError)
-                })
             }
 
             let params = [
@@ -55,11 +42,21 @@ class ContentViewsService: HTTPService {
                 "context_from": context.rawValue
                 ]
 
-            _ = self.request(method: .POST,
-                             path: "content-views/",
-                             params: params,
-                             success: successBlock,
-                             fail: failBlock)
+            let httpHandler: ((Result <Data?, Error>) -> Void) = { result in
+                switch result {
+                case .success(_):
+                    DispatchQueue.main.async(execute: {
+                        handler?(.success(nil))
+                    })
+
+                case .failure(let error):
+                    DispatchQueue.main.async(execute: {
+                        handler?(.failure(error))
+                    })
+                }
+            }
+
+            _ = self?.request(method: .POST, path: "content-views/", params: params, handler: httpHandler)
         }
     }
 }

--- a/Headlines/src/Services/ContentViewsService.swift
+++ b/Headlines/src/Services/ContentViewsService.swift
@@ -44,7 +44,7 @@ class ContentViewsService: HTTPService {
 
             let httpHandler: ((Result <Data?, Error>) -> Void) = { result in
                 switch result {
-                case .success(_):
+                case .success:
                     DispatchQueue.main.async(execute: {
                         handler?(.success(nil))
                     })

--- a/Headlines/src/Services/InterestsService.swift
+++ b/Headlines/src/Services/InterestsService.swift
@@ -10,40 +10,22 @@ import UIKit
 import CloudKit
 
 class InterestsService: HTTPService {
-    func getInterests(success: ((_ response: URLResponse?, [Interest]) -> Void)?,
-                      fail: ((_ error: Error) -> Void)?) {
 
-        let successBlock: (_ result: Data?, _ response: URLResponse?) -> Void = {(data, response) in
-            guard let d = data else {
-                return
-            }
+    func getInterests(handler: ((_ result: Result <[Interest], Error>) -> Void)?) {
 
-            let interests = (try? JSONDecoder().decode([Interest].self, from: d)) ?? [Interest]()
-
-            DispatchQueue.main.async(execute: {
-                success?(response, interests)
-            })
-        }
-
-        let failBlock: (_ error: NSError) -> Void = { (e) in
-            DispatchQueue.main.async(execute: {
-                fail?(e as NSError)
-            })
-        }
-
-        if ProcessInfo.processInfo.arguments.contains("mockRequests") {
-            let mockService = MockService()
-            _ = mockService.request(file: "GET-interests",
-                                    success: successBlock,
-                                    fail: failBlock)
-            return
-        }
+//        if ProcessInfo.processInfo.arguments.contains("mockRequests") {
+//            let mockService = MockService()
+//            _ = mockService.request(file: "GET-interests",
+//                                    success: successBlock,
+//                                    fail: failBlock)
+//            return
+//        }
 
         let container = CKContainer.default()
         container.fetchUserRecordID { (recordId, error) in
             if let err = error {
                 DispatchQueue.main.async(execute: {
-                    fail?(err)
+                    handler?(.failure(err))
                 })
                 return
             }
@@ -55,16 +37,37 @@ class InterestsService: HTTPService {
                                   userInfo: errUserInfo)
 
                 DispatchQueue.main.async(execute: {
-                    fail?(err)
+                    handler?(.failure(err))
                 })
                 return
             }
 
-            _ = self.request(method: .GET,
-                             path: "interests/\(userId.recordName)/iOS",
+            let httpHandler: ((Result <Data?, Error>) -> Void) = { result in
+                switch result {
+                case .success(let data):
+                    guard let d = data else {
+                        handler?(.success([Interest]()))
+                        return
+                    }
+
+                    let res = (try? JSONDecoder().decode([Interest].self, from: d)) ?? [Interest]()
+
+                    DispatchQueue.main.async(execute: {
+                        handler?(.success(res))
+                    })
+
+                case .failure(let error):
+                    handler?(.failure(error))
+                    return
+                }
+            }
+
+            _ = self.request(
+                method: .GET,
+                path: "interests/\(userId.recordName)/iOS",
                 params: nil,
-                success: successBlock,
-                fail: failBlock)
+                handler: httpHandler
+            )
         }
     }
 }

--- a/Headlines/src/Services/InterestsService.swift
+++ b/Headlines/src/Services/InterestsService.swift
@@ -13,10 +13,10 @@ class InterestsService: HTTPService {
 
     func getInterests(handler: ((_ result: Result <[Interest], Error>) -> Void)?) {
 
-        let httpHandler: ((Result <Data?, Error>) -> Void) = { result in
+        let httpHandler: ((HTTPResult) -> Void) = { result in
             switch result {
-            case .success(let data):
-                guard let d = data else {
+            case .success(let success):
+                guard let d = success.data else {
                     handler?(.success([Interest]()))
                     return
                 }

--- a/Headlines/src/Services/InterestsService.swift
+++ b/Headlines/src/Services/InterestsService.swift
@@ -13,14 +13,6 @@ class InterestsService: HTTPService {
 
     func getInterests(handler: ((_ result: Result <[Interest], Error>) -> Void)?) {
 
-//        if ProcessInfo.processInfo.arguments.contains("mockRequests") {
-//            let mockService = MockService()
-//            _ = mockService.request(file: "GET-interests",
-//                                    success: successBlock,
-//                                    fail: failBlock)
-//            return
-//        }
-
         let container = CKContainer.default()
         container.fetchUserRecordID { (recordId, error) in
             if let err = error {
@@ -60,6 +52,12 @@ class InterestsService: HTTPService {
                     handler?(.failure(error))
                     return
                 }
+            }
+
+            if ProcessInfo.processInfo.arguments.contains("mockRequests") {
+                let mockService = MockService()
+                _ = mockService.request(file: "GET-interests", handler: httpHandler)
+                return
             }
 
             _ = self.request(

--- a/Headlines/src/Services/ReactionsService.swift
+++ b/Headlines/src/Services/ReactionsService.swift
@@ -66,14 +66,6 @@ class ReactionsService: HTTPService {
 
     func getReactions(handler: ((_ result: Result <[Reaction], Error>) -> Void)?) {
 
-//        if ProcessInfo.processInfo.arguments.contains("mockRequests") {
-//            let mockService = MockService()
-//            _ = mockService.request(file: "GET-reactions",
-//                                    success: successBlock,
-//                                    fail: failBlock)
-//            return
-//        }
-
         let container = CKContainer.default()
         container.fetchUserRecordID { (recordId, error) in
             if let err = error {
@@ -112,6 +104,12 @@ class ReactionsService: HTTPService {
                 case .failure(let error):
                     handler?(.failure(error))
                 }
+            }
+
+            if ProcessInfo.processInfo.arguments.contains("mockRequests") {
+                let mockService = MockService()
+                _ = mockService.request(file: "GET-reactions", handler: httpHandler)
+                return
             }
 
             _ = self.request(

--- a/Headlines/src/Services/ReactionsService.swift
+++ b/Headlines/src/Services/ReactionsService.swift
@@ -64,7 +64,7 @@ class ReactionsService: HTTPService {
         }
     }
 
-    func getReactions(handler: ((_ result: Result <[Reaction]?, Error>) -> Void)?) {
+    func getReactions(handler: ((_ result: Result <[Reaction], Error>) -> Void)?) {
 
 //        if ProcessInfo.processInfo.arguments.contains("mockRequests") {
 //            let mockService = MockService()
@@ -99,10 +99,11 @@ class ReactionsService: HTTPService {
                 switch result {
                 case .success(let data):
                     guard let d = data else {
+                        handler?(.success([]))
                         return
                     }
 
-                    let res = try! JSONDecoder().decode([Reaction].self, from: d)
+                    let res = (try? JSONDecoder().decode([Reaction].self, from: d)) ?? []
 
                     DispatchQueue.main.async(execute: {
                         handler?(.success(res))

--- a/Headlines/src/Services/ReactionsService.swift
+++ b/Headlines/src/Services/ReactionsService.swift
@@ -14,14 +14,13 @@ class ReactionsService: HTTPService {
 
     func postReaction(_ reaction: String,
                       atPost postId: String,
-                      success: ((_ response: URLResponse?, News?) -> Void)?,
-                      fail: ((_ error: Error) -> Void)?) {
+                      handler: ((_ response: Result <News?, Error>) -> Void)?) {
 
         let container = CKContainer.default()
         container.fetchUserRecordID { (recordId, error) in
             if let err = error {
                 DispatchQueue.main.async(execute: {
-                    fail?(err)
+                    handler?(.failure(err))
                 })
                 return
             }
@@ -32,27 +31,27 @@ class ReactionsService: HTTPService {
                                   code: 1,
                                   userInfo: errUserInfo)
                 DispatchQueue.main.async(execute: {
-                    fail?(err)
+                    handler?(.failure(err))
                 })
                 return
             }
 
-            let successBlock: (_ result: Data?, _ response: URLResponse?) -> Void = {(data, response) in
-                guard let d = data else {
-                    return
+            let httpHandler: ((Result <Data?, Error>) -> Void) = { result in
+                switch result {
+                case .success(let data):
+                    guard let d = data else {
+                        return
+                    }
+
+                    let res = try! JSONDecoder().decode(News.self, from: d)
+
+                    DispatchQueue.main.async(execute: {
+                        handler?(.success(res))
+                    })
+
+                case .failure(let error):
+                    handler?(.failure(error))
                 }
-
-                let n = try? JSONDecoder().decode(News.self, from: d)
-
-                DispatchQueue.main.async(execute: {
-                    success?(response, n)
-                })
-            }
-
-            let failBlock: (_ error: NSError) -> Void = { (e) in
-                DispatchQueue.main.async(execute: {
-                    fail?(e as NSError)
-                })
             }
 
             let params = [
@@ -61,48 +60,25 @@ class ReactionsService: HTTPService {
                 "user_id": userId.recordName
             ]
 
-            _ = self.request(method: .POST,
-                             path: "reactions/\(postId)",
-                             params: params,
-                             success: successBlock,
-                             fail: failBlock)
+            _ = self.request(method: .POST, path: "reactions/\(postId)", params: params, handler: httpHandler)
         }
     }
 
-    func getReactions(success: ((_ response: URLResponse?, [Reaction]) -> Void)?,
-                      fail: ((_ error: Error) -> Void)?) {
+    func getReactions(handler: ((_ result: Result <[Reaction]?, Error>) -> Void)?) {
 
-        let successBlock: (_ result: Data?, _ response: URLResponse?) -> Void = {(data, response) in
-            guard let d = data else {
-                return
-            }
-
-            let reactions = try! JSONDecoder().decode([Reaction].self, from: d)
-
-            DispatchQueue.main.async(execute: {
-                success?(response, reactions)
-            })
-        }
-
-        let failBlock: (_ error: NSError) -> Void = { (e) in
-            DispatchQueue.main.async(execute: {
-                fail?(e as NSError)
-            })
-        }
-
-        if ProcessInfo.processInfo.arguments.contains("mockRequests") {
-            let mockService = MockService()
-            _ = mockService.request(file: "GET-reactions",
-                                    success: successBlock,
-                                    fail: failBlock)
-            return
-        }
+//        if ProcessInfo.processInfo.arguments.contains("mockRequests") {
+//            let mockService = MockService()
+//            _ = mockService.request(file: "GET-reactions",
+//                                    success: successBlock,
+//                                    fail: failBlock)
+//            return
+//        }
 
         let container = CKContainer.default()
         container.fetchUserRecordID { (recordId, error) in
             if let err = error {
                 DispatchQueue.main.async(execute: {
-                    fail?(err)
+                    handler?(.failure(err))
                 })
                 return
             }
@@ -114,16 +90,35 @@ class ReactionsService: HTTPService {
                                   userInfo: errUserInfo)
 
                 DispatchQueue.main.async(execute: {
-                    fail?(err)
+                    handler?(.failure(err))
                 })
                 return
             }
 
-            _ = self.request(method: .GET,
-                             path: "reactions/\(userId.recordName)/iOS",
-                             params: nil,
-                             success: successBlock,
-                             fail: failBlock)
+            let httpHandler: ((Result <Data?, Error>) -> Void) = { result in
+                switch result {
+                case .success(let data):
+                    guard let d = data else {
+                        return
+                    }
+
+                    let res = try! JSONDecoder().decode([Reaction].self, from: d)
+
+                    DispatchQueue.main.async(execute: {
+                        handler?(.success(res))
+                    })
+
+                case .failure(let error):
+                    handler?(.failure(error))
+                }
+            }
+
+            _ = self.request(
+                method: .GET,
+                path: "reactions/\(userId.recordName)/iOS",
+                params: nil,
+                handler: httpHandler
+            )
         }
     }
 }

--- a/Headlines/src/Services/ReactionsService.swift
+++ b/Headlines/src/Services/ReactionsService.swift
@@ -36,14 +36,15 @@ class ReactionsService: HTTPService {
                 return
             }
 
-            let httpHandler: ((Result <Data?, Error>) -> Void) = { result in
+            let httpHandler: ((HTTPResult) -> Void) = { result in
                 switch result {
-                case .success(let data):
-                    guard let d = data else {
+                case .success(let success):
+                    guard let d = success.data else {
+                        handler?(.success(nil))
                         return
                     }
 
-                    let res = try! JSONDecoder().decode(News.self, from: d)
+                    let res = try? JSONDecoder().decode(News.self, from: d)
 
                     DispatchQueue.main.async(execute: {
                         handler?(.success(res))
@@ -66,10 +67,10 @@ class ReactionsService: HTTPService {
 
     func getReactions(handler: ((_ result: Result <[Reaction], Error>) -> Void)?) {
 
-        let httpHandler: ((Result <Data?, Error>) -> Void) = { result in
+        let httpHandler: ((HTTPResult) -> Void) = { result in
             switch result {
-            case .success(let data):
-                guard let d = data else {
+            case .success(let success):
+                guard let d = success.data else {
                     handler?(.success([]))
                     return
                 }

--- a/Headlines/src/Services/UsersService.swift
+++ b/Headlines/src/Services/UsersService.swift
@@ -12,7 +12,7 @@ import CloudKit
 class UsersService: HTTPService {
 
     func postDeviceToken(_ token: String,
-                         handler: ((_ result: Result<Data?, Error>) -> Void)?) {
+                         handler: ((_ result: Result<URLResponse?, Error>) -> Void)?) {
 
         let container = CKContainer.default()
         container.fetchUserRecordID { (recordId, error) in
@@ -36,11 +36,11 @@ class UsersService: HTTPService {
                 "user_id": userId.recordName
             ]
 
-            let httpHandler: ((Result <Data?, Error>) -> Void) = { result in
+            let httpHandler: ((HTTPResult) -> Void) = { result in
                 switch result {
-                case .success(let data):
+                case .success(let success):
                     DispatchQueue.main.async(execute: {
-                        handler?(.success(data))
+                        handler?(.success(success.response))
                     })
 
                 case .failure(let error):

--- a/Headlines/src/Services/UsersService.swift
+++ b/Headlines/src/Services/UsersService.swift
@@ -12,13 +12,12 @@ import CloudKit
 class UsersService: HTTPService {
 
     func postDeviceToken(_ token: String,
-                         success: ((_ response: URLResponse?) -> Void)?,
-                         fail: ((_ error: Error) -> Void)?) {
+                         handler: ((_ result: Result<Data?, Error>) -> Void)?) {
 
         let container = CKContainer.default()
         container.fetchUserRecordID { (recordId, error) in
             if let err = error {
-                fail?(err)
+                handler?(.failure(err))
                 return
             }
 
@@ -27,20 +26,8 @@ class UsersService: HTTPService {
                 let err = NSError(domain: "ReactionsService",
                                   code: 1,
                                   userInfo: errUserInfo)
-                fail?(err)
+                handler?(.failure(err))
                 return
-            }
-
-            let successBlock: (_ result: Data?, _ response: URLResponse?) -> Void = {(data, response) in
-                DispatchQueue.main.async(execute: {
-                    success?(response)
-                })
-            }
-
-            let failBlock: (_ error: NSError) -> Void = { (e) in
-                DispatchQueue.main.async(execute: {
-                    fail?(e as NSError)
-                })
             }
 
             let params = [
@@ -49,13 +36,22 @@ class UsersService: HTTPService {
                 "user_id": userId.recordName
             ]
 
-            _ = self.request(
-                method: .POST,
-                path: "users/devicetoken",
-                params: params,
-                success: successBlock,
-                fail: failBlock
-            )
+            let httpHandler: ((Result <Data?, Error>) -> Void) = { result in
+                switch result {
+                case .success(let data):
+                    DispatchQueue.main.async(execute: {
+                        handler?(.success(data))
+                    })
+
+                case .failure(let error):
+                    DispatchQueue.main.async(execute: {
+                        handler?(.failure(error))
+                    })
+                    return
+                }
+            }
+
+            _ = self.request(method: .POST, path: "users/devicetoken", params: params, handler: httpHandler)
         }
     }
 }

--- a/Headlines/src/Views/LabelCollectionViewCell.swift
+++ b/Headlines/src/Views/LabelCollectionViewCell.swift
@@ -32,7 +32,10 @@ class LabelCollectionViewCell: UICollectionViewCell {
     }
 
     private func setupLabel() {
-        label = UILabel(frame: .zero)
+        // Setting this to a local variable and then assigning it to the property
+        // because otherwise I get "Expression implicitly coerced from 'UILabel?' to 'Any'"
+
+        let label = UILabel(frame: .zero)
         label.translatesAutoresizingMaskIntoConstraints = false
         label.font = LabelCollectionViewCell.defaultFont
         label.textColor = normalTextColor
@@ -73,6 +76,7 @@ class LabelCollectionViewCell: UICollectionViewCell {
 
         let constraints = [leftConstraint, topConstraint, rightConstraint, bottomConstraint]
         self.addConstraints(constraints)
+        self.label = label
     }
 
     override init(frame: CGRect) {

--- a/HeadlinesMockedUITests/HeadlinesMockedUITests.swift
+++ b/HeadlinesMockedUITests/HeadlinesMockedUITests.swift
@@ -52,44 +52,50 @@ class HeadlinesMockedUITests: XCTestCase {
     }
 
     func testMockedPopularNews() {
-        let app = XCUIApplication()
-
-        //  Go to Popular tab
-        app.tabBars.buttons["Popular"].tap()
-
-        let cell = app.tables.cells.element(boundBy: 0)
         let exists = NSPredicate(format: "exists == 1")
+
+        let tab = XCUIApplication().tabBars.buttons["Popular"]
+        let tabBarExpectation = expectation(for: exists, evaluatedWith: tab) { () -> Bool in
+            tab.tap()
+            return true
+        }
+
+        let cell = XCUIApplication().tables.cells.element(boundBy: 0)
         let cellExistsExpectation = expectation(for: exists, evaluatedWith: cell, handler: nil)
-        wait(for: [cellExistsExpectation], timeout: defaultWaitThreshold)
+        wait(for: [tabBarExpectation, cellExistsExpectation], timeout: defaultWaitThreshold)
     }
 
     func testMockedRecentNews() {
-        let app = XCUIApplication()
-
-        //  Go to Reciente tab
-        app.tabBars.buttons["Reciente"].tap()
-
-        let cell = app.tables.cells.element(boundBy: 0)
         let exists = NSPredicate(format: "exists == 1")
+
+        let tab = XCUIApplication().tabBars.buttons["Reciente"]
+        let tabBarExpectation = expectation(for: exists, evaluatedWith: tab) { () -> Bool in
+            tab.tap()
+            return true
+        }
+
+        let cell = XCUIApplication().tables.cells.element(boundBy: 0)
         let cellExistsExpectation = expectation(for: exists, evaluatedWith: cell, handler: nil)
-        wait(for: [cellExistsExpectation], timeout: defaultWaitThreshold)
+        wait(for: [tabBarExpectation, cellExistsExpectation], timeout: defaultWaitThreshold)
     }
 
     func testReactionScreenFromMockedRecentNews() {
-        let app = XCUIApplication()
-
-        //  Go to Reciente tab
-        app.tabBars.buttons["Reciente"].tap()
-
-        let cell = app.tables.cells.element(boundBy: 1)
         let exists = NSPredicate(format: "exists == 1")
+
+        let tab = XCUIApplication().tabBars.buttons["Reciente"]
+        let tabBarExpectation = expectation(for: exists, evaluatedWith: tab) { () -> Bool in
+            tab.tap()
+            return true
+        }
+
+        let cell = XCUIApplication().tables.cells.element(boundBy: 0)
         let cellExistsExpectation = expectation(for: exists, evaluatedWith: cell, handler: nil)
-        wait(for: [cellExistsExpectation], timeout: defaultWaitThreshold)
+        wait(for: [tabBarExpectation, cellExistsExpectation], timeout: defaultWaitThreshold)
 
         //  Go to reacciones by tapping the "reaction button"
         cell.buttons["add reaction icon"].tap()
 
-        let reaccionesStaticText = app.navigationBars["Reacciones"].otherElements["Reacciones"]
+        let reaccionesStaticText = XCUIApplication().navigationBars["Reacciones"].otherElements["Reacciones"]
         let reaccionesTitleLabelExpectation = expectation(for: exists,
                                                           evaluatedWith: reaccionesStaticText,
                                                           handler: nil)
@@ -97,27 +103,36 @@ class HeadlinesMockedUITests: XCTestCase {
     }
 
     func testReactionScreenFromMockedSearch() {
-        let app = XCUIApplication()
-
-        //  Go to search
-        app.tabBars.buttons["Buscar"].tap()
-
-        //  Tap search text input
-        let buscarSearchField = app.searchFields["Buscar"]
-        buscarSearchField.tap()
-
-        //  Type "Calu rivero" and ENTER
-        buscarSearchField.typeText("Calu rivero\r")
-
-        let cell = app.tables["search table"].cells.element(boundBy: 0)
         let exists = NSPredicate(format: "exists == 1")
+
+        let tab = XCUIApplication().tabBars.buttons["Buscar"]
+        let tabBarExpectation = expectation(for: exists, evaluatedWith: tab) { () -> Bool in
+            tab.tap()
+            return true
+        }
+
+        wait(for: [tabBarExpectation], timeout: defaultWaitThreshold)
+
+        let searchField = XCUIApplication().navigationBars["Buscar"].searchFields["Buscar"]
+        let searchFieldExistsExpectation = expectation(for: exists, evaluatedWith: searchField, handler: nil)
+        wait(for: [searchFieldExistsExpectation], timeout: defaultWaitThreshold)
+
+        //  Type "Calu"
+        searchField.tap()
+        searchField.typeText("Calu")
+        XCUIApplication().navigationBars["Buscar"].searchFields["Buscar"].tap()
+
+        //  Enter
+        searchField.typeText("\r")
+        let cell = XCUIApplication().tables["search table"].cells.element(boundBy: 0)
+
         let cellExistsExpectation = expectation(for: exists, evaluatedWith: cell, handler: nil)
         wait(for: [cellExistsExpectation], timeout: defaultWaitThreshold)
 
         //  Go to reacciones by tapping the "reaction button"
         cell.buttons["add reaction icon"].tap()
 
-        let reaccionesStaticText = app.navigationBars["Reacciones"].otherElements["Reacciones"]
+        let reaccionesStaticText = XCUIApplication().navigationBars["Reacciones"]
         let reaccionesTitleLabelExpectation = expectation(for: exists,
                                                           evaluatedWith: reaccionesStaticText,
                                                           handler: nil)
@@ -162,7 +177,7 @@ class HeadlinesMockedUITests: XCTestCase {
         cell.tap()
 
         // Check that a new controller is pushed and dismissed correctly
-        let navigationBar = app.navigationBars["Macri"]
+        let navigationBar = app.navigationBars["Kim"]
         let navigationExists = navigationBar.waitForExistence(timeout: defaultWaitThreshold)
         XCTAssert(navigationExists)
 

--- a/HeadlinesMockedUITests/HeadlinesMockedUITests.swift
+++ b/HeadlinesMockedUITests/HeadlinesMockedUITests.swift
@@ -177,7 +177,7 @@ class HeadlinesMockedUITests: XCTestCase {
         cell.tap()
 
         // Check that a new controller is pushed and dismissed correctly
-        let navigationBar = app.navigationBars["Kim"]
+        let navigationBar = app.navigationBars["Macri"]
         let navigationExists = navigationBar.waitForExistence(timeout: defaultWaitThreshold)
         XCTAssert(navigationExists)
 

--- a/HeadlinesTests/PopularNewsDataSourceTests.swift
+++ b/HeadlinesTests/PopularNewsDataSourceTests.swift
@@ -16,16 +16,17 @@ class PopularNewsDataSourceTests: XCTestCase {
     func testFetchNews() {
         let exp = expectation(description: "Get fake response from JSON file")
 
-        let success: ([News]) -> Void = { (news) in
-            exp.fulfill()
+        let handler: ((Result<[News], Error>) -> Void) = { result in
+            switch result {
+            case .success(_):
+                exp.fulfill()
+
+            case .failure(let error):
+                XCTFail(error.localizedDescription)
+            }
         }
 
-        let fail: (NSError) -> Void = { (error) in
-            XCTFail(error.localizedDescription)
-        }
-
-        self.dataSource.fetchNews(page: 1, success: success, fail: fail)
-
+        self.dataSource.fetchNews(page: 1, handler: handler)
         wait(for: [exp], timeout: 10)
     }
 

--- a/HeadlinesTests/PopularNewsDataSourceTests.swift
+++ b/HeadlinesTests/PopularNewsDataSourceTests.swift
@@ -18,7 +18,7 @@ class PopularNewsDataSourceTests: XCTestCase {
 
         let handler: ((Result<[News], Error>) -> Void) = { result in
             switch result {
-            case .success(_):
+            case .success:
                 exp.fulfill()
 
             case .failure(let error):

--- a/HeadlinesTests/RecentNewsDataSourceTests.swift
+++ b/HeadlinesTests/RecentNewsDataSourceTests.swift
@@ -16,15 +16,17 @@ class RecentNewsDataSourceTests: XCTestCase {
     func testFetchNews() {
         let exp = expectation(description: "Get fake response from JSON file")
 
-        let success: ([News]) -> Void = { (_) in
-            exp.fulfill()
+        let handler: ((Result<[News], Error>) -> Void) = { result in
+            switch result {
+            case .success(_):
+                exp.fulfill()
+
+            case .failure(let error):
+                XCTFail(error.localizedDescription)
+            }
         }
 
-        let fail: (NSError) -> Void = { (error) in
-            XCTFail(error.localizedDescription)
-        }
-
-        self.dataSource.fetchNews(page: 1, success: success, fail: fail)
+        self.dataSource.fetchNews(page: 1, handler: handler)
         wait(for: [exp], timeout: 10)
     }
 

--- a/HeadlinesTests/RecentNewsDataSourceTests.swift
+++ b/HeadlinesTests/RecentNewsDataSourceTests.swift
@@ -18,7 +18,7 @@ class RecentNewsDataSourceTests: XCTestCase {
 
         let handler: ((Result<[News], Error>) -> Void) = { result in
             switch result {
-            case .success(_):
+            case .success:
                 exp.fulfill()
 
             case .failure(let error):

--- a/HeadlinesUITests/HeadlinesUITests.swift
+++ b/HeadlinesUITests/HeadlinesUITests.swift
@@ -39,26 +39,30 @@ class HeadlinesUITests: XCTestCase {
     }
 
     func testPopularNews() {
-        let app = XCUIApplication()
-
-        //  Go to Popular tab
-        app.tabBars.buttons["Popular"].tap()
-
-        let cell = app.tables.cells.element(boundBy: 0)
         let exists = NSPredicate(format: "exists == 1")
+
+        let tab = XCUIApplication().tabBars.buttons["Popular"]
+        let tabBarExpectation = expectation(for: exists, evaluatedWith: tab) { () -> Bool in
+            tab.tap()
+            return true
+        }
+
+        let cell = XCUIApplication().tables.cells.element(boundBy: 0)
         let cellExistsExpectation = expectation(for: exists, evaluatedWith: cell, handler: nil)
-        wait(for: [cellExistsExpectation], timeout: defaultWaitThreshold)
+        wait(for: [tabBarExpectation, cellExistsExpectation], timeout: defaultWaitThreshold)
     }
 
     func testRecentNews() {
-        let app = XCUIApplication()
-
-        //  Go to Reciente tab
-        app.tabBars.buttons["Reciente"].tap()
-
-        let cell = app.tables.cells.element(boundBy: 0)
         let exists = NSPredicate(format: "exists == 1")
+
+        let tab = XCUIApplication().tabBars.buttons["Reciente"]
+        let tabBarExpectation = expectation(for: exists, evaluatedWith: tab) { () -> Bool in
+            tab.tap()
+            return true
+        }
+
+        let cell = XCUIApplication().tables.cells.element(boundBy: 0)
         let cellExistsExpectation = expectation(for: exists, evaluatedWith: cell, handler: nil)
-        wait(for: [cellExistsExpectation], timeout: defaultWaitThreshold)
+        wait(for: [tabBarExpectation, cellExistsExpectation], timeout: defaultWaitThreshold)
     }
 }

--- a/Notifications/NotificationService.swift
+++ b/Notifications/NotificationService.swift
@@ -24,7 +24,9 @@ class NotificationService: UNNotificationServiceExtension {
                 isDirectory: true)
 
             do {
-                try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true, attributes: nil)
+                try FileManager.default.createDirectory(at: directory,
+                                                        withIntermediateDirectories: true,
+                                                        attributes: nil)
 
                 let fileURL = directory.appendingPathComponent(identifier)
                 try data.write(to: fileURL, options: [])

--- a/SnapshotUITests/SnapshotUITests.swift
+++ b/SnapshotUITests/SnapshotUITests.swift
@@ -54,45 +54,51 @@ class SnapshotUITests: XCTestCase {
     }
 
     func testPopularNews() {
-        let app = XCUIApplication()
-
-        //  Go to Popular tab
-        app.tabBars.buttons["Popular"].tap()
-
-        let cell = app.tables.cells.element(boundBy: 0)
         let exists = NSPredicate(format: "exists == 1")
+
+        let tab = XCUIApplication().tabBars.buttons["Popular"]
+        let tabBarExpectation = expectation(for: exists, evaluatedWith: tab) { () -> Bool in
+            tab.tap()
+            return true
+        }
+
+        let cell = XCUIApplication().tables.cells.element(boundBy: 0)
         let cellExistsExpectation = expectation(for: exists, evaluatedWith: cell, handler: nil)
-        wait(for: [cellExistsExpectation], timeout: defaultWaitThreshold)
+        wait(for: [tabBarExpectation, cellExistsExpectation], timeout: defaultWaitThreshold)
         sleep(5)
         snapshot("02-popular")
     }
 
     func testRecentNews() {
-        let app = XCUIApplication()
-
-        //  Go to Reciente tab
-        app.tabBars.buttons["Reciente"].tap()
-
-        let cell = app.tables.cells.element(boundBy: 0)
         let exists = NSPredicate(format: "exists == 1")
+
+        let tab = XCUIApplication().tabBars.buttons["Reciente"]
+        let tabBarExpectation = expectation(for: exists, evaluatedWith: tab) { () -> Bool in
+            tab.tap()
+            return true
+        }
+
+        let cell = XCUIApplication().tables.cells.element(boundBy: 0)
         let cellExistsExpectation = expectation(for: exists, evaluatedWith: cell, handler: nil)
-        wait(for: [cellExistsExpectation], timeout: defaultWaitThreshold)
+        wait(for: [tabBarExpectation, cellExistsExpectation], timeout: defaultWaitThreshold)
         sleep(5)
         snapshot("03-recent-news")
     }
 
     func testRecentNewsFilter() {
-        let app = XCUIApplication()
-
-        //  Go to Reciente tab
-        app.tabBars.buttons["Reciente"].tap()
-
-        let cell = app.tables.cells.element(boundBy: 0)
         let exists = NSPredicate(format: "exists == 1")
+
+        let tab = XCUIApplication().tabBars.buttons["Reciente"]
+        let tabBarExpectation = expectation(for: exists, evaluatedWith: tab) { () -> Bool in
+            tab.tap()
+            return true
+        }
+
+        let cell = XCUIApplication().tables.cells.element(boundBy: 0)
         let cellExistsExpectation = expectation(for: exists, evaluatedWith: cell, handler: nil)
-        wait(for: [cellExistsExpectation], timeout: defaultWaitThreshold)
+        wait(for: [tabBarExpectation, cellExistsExpectation], timeout: defaultWaitThreshold)
         sleep(2)
-        app.navigationBars["Reciente"].buttons["filter icon"].tap()
+        XCUIApplication().navigationBars["Reciente"].buttons["filter icon"].tap()
         sleep(2)
         snapshot("03-recent-news-filter")
     }
@@ -114,15 +120,17 @@ class SnapshotUITests: XCTestCase {
     }
 
     func testReactionScreenFromMockedSearch() {
-
-        let app = XCUIApplication()
-
-        //  Go to "Buscar"
-        app.tabBars.buttons["Buscar"].tap()
-
         let exists = NSPredicate(format: "exists == 1")
 
-        let searchField = app.navigationBars["Buscar"].searchFields["Buscar"]
+        let tab = XCUIApplication().tabBars.buttons["Buscar"]
+        let tabBarExpectation = expectation(for: exists, evaluatedWith: tab) { () -> Bool in
+            tab.tap()
+            return true
+        }
+
+        wait(for: [tabBarExpectation], timeout: defaultWaitThreshold)
+
+        let searchField = XCUIApplication().navigationBars["Buscar"].searchFields["Buscar"]
         let searchFieldExistsExpectation = expectation(for: exists, evaluatedWith: searchField, handler: nil)
         wait(for: [searchFieldExistsExpectation], timeout: defaultWaitThreshold)
         snapshot("05-search-trending")
@@ -135,7 +143,7 @@ class SnapshotUITests: XCTestCase {
 
         //  Enter
         searchField.typeText("\r")
-        let cell = app.tables["search table"].cells.element(boundBy: 0)
+        let cell = XCUIApplication().tables["search table"].cells.element(boundBy: 0)
 
         let cellExistsExpectation = expectation(for: exists, evaluatedWith: cell, handler: nil)
         wait(for: [cellExistsExpectation], timeout: defaultWaitThreshold)
@@ -145,7 +153,7 @@ class SnapshotUITests: XCTestCase {
         //  Go to reacciones by tapping the "reaction button"
         cell.buttons["add reaction icon"].tap()
 
-        let reaccionesStaticText = app.navigationBars["Reacciones"]
+        let reaccionesStaticText = XCUIApplication().navigationBars["Reacciones"]
         let reaccionesTitleLabelExpectation = expectation(for: exists,
                                                           evaluatedWith: reaccionesStaticText,
                                                           handler: nil)

--- a/Watch Extension/TrendingInterfaceController.swift
+++ b/Watch Extension/TrendingInterfaceController.swift
@@ -31,22 +31,25 @@ class TrendingInterfaceController: WKInterfaceController {
 
     func fetchTrendingNews() {
         showLoadingIndicator(true)
-        _ = newsService.requestTrendingTopicsWithDate(Date(), count: 6, success: { (result) in
-            self.topics = result?.topics
 
-            guard let topics = self.topics else {
-                return
+        _ = newsService.requestTrendingTopicsWithDate(Date(), count: 6, handler: { result in
+            if case .success(let topicList) = result {
+                self.topics = topicList?.topics
+
+                guard let topics = self.topics else {
+                    return
+                }
+
+                self.trendingTable.setNumberOfRows(topics.count, withRowType: "TrendingRow")
+
+                for (index, t) in topics.enumerated() {
+                    let row = self.trendingTable.rowController(at: index) as! TrendingRowController
+                    row.titleLabel.setText(t.name)
+                }
+                self.showLoadingIndicator(false)
+                self.lastFetch = Date()
             }
-
-            self.trendingTable.setNumberOfRows(topics.count, withRowType: "TrendingRow")
-
-            for (index, t) in topics.enumerated() {
-                let row = self.trendingTable.rowController(at: index) as! TrendingRowController
-                row.titleLabel.setText(t.name)
-            }
-            self.showLoadingIndicator(false)
-            self.lastFetch = Date()
-            }, fail: nil)
+        })
     }
 
     override func awake(withContext context: Any?) {


### PR DESCRIPTION
As discussed [here](https://nslog.dev/t/result-t-e-vs-par-de-callbacks), I replaced all `successBlock` and `failBlock` in favor of `Result <something, Error>` type. 

Result was introduced with Swift 5, you can read more about it [here](https://github.com/apple/swift-evolution/blob/master/proposals/0235-add-result.md)